### PR TITLE
[backend] broken links to editor with linkHref helper

### DIFF
--- a/logigator-backend/src/handlebars-helper/linkHref.helper.ts
+++ b/logigator-backend/src/handlebars-helper/linkHref.helper.ts
@@ -1,6 +1,10 @@
 import {HelperDelegate, HelperOptions} from 'handlebars';
+import {Container} from 'typedi';
+import {ConfigService} from '../services/config.service';
 
 export function linkHrefHelper(): HelperDelegate {
+	const editorUrl = Container.get(ConfigService).getConfig('domains').editor;
+
 	return function(url: string, options: HelperOptions) {
 		if (arguments.length < 2) {
 			throw new Error('handlebars Helper {{linkHref}} expects 1 arguments (link: string)');
@@ -8,6 +12,11 @@ export function linkHrefHelper(): HelperDelegate {
 
 		if (url === '/') {
 			return '/' + options.data.root.preferences.lang;
+		}
+
+		// Editor URL is not prefixed with language
+		if (url.startsWith(editorUrl)) {
+			return url;
 		}
 
 		return '/' + options.data.root.preferences.lang + (url.startsWith('/') ? url : '/' + url);


### PR DESCRIPTION
This pull request updates the `linkHrefHelper` in the backend to correctly handle URLs for the editor by avoiding adding a language prefix to editor links. This ensures that links to the editor domain are generated as expected, while all other links continue to be prefixed with the user's language.

**URL handling improvements:**

* The `linkHrefHelper` now checks if a URL starts with the editor domain (retrieved from the configuration via `ConfigService`), and if so, returns the URL unchanged, preventing the language prefix from being added. [[1]](diffhunk://#diff-bfbef1cf4fec323b5ad6b296954faf30e1023d3757486054248137b544ef374cR2-R7) [[2]](diffhunk://#diff-bfbef1cf4fec323b5ad6b296954faf30e1023d3757486054248137b544ef374cR17-R21)
* For all other URLs, the helper continues to prefix the URL with the user's language as before.