### PR TITLE
Fix asset replacement for WASM file in JS during copy simulation

### DIFF
--- a/logigator-editor/custom-build-scripts/copy-simulation-assets.ts
+++ b/logigator-editor/custom-build-scripts/copy-simulation-assets.ts
@@ -33,8 +33,8 @@ async function run() {
 	const wasmHash = createHash('md5').update(wasmFile).digest('base64url');
 
 	jsFile = jsFile.replace(
-		/var wasmBinaryFile ?= ?["'](.*?)["'];/,
-		`var wasmBinaryFile=\'assets/wasm/logigator-simulation.${wasmHash}.wasm\';`
+		'logigator-simulation.wasm',
+		`assets/wasm/logigator-simulation.${wasmHash}.wasm`
 	);
 
 	const existingFiles = await readdir(dest, { recursive: false });


### PR DESCRIPTION
This pull request updates how the WebAssembly (WASM) asset path is replaced in the JavaScript file during the simulation asset copy process. Instead of replacing a specific variable assignment, it now directly replaces the filename string, making the replacement logic simpler and more robust.

**Asset path replacement simplification:**

* In `logigator-editor/custom-build-scripts/copy-simulation-assets.ts`, the code now replaces all instances of `'logigator-simulation.wasm'` with the hashed asset path, rather than targeting the `wasmBinaryFile` variable assignment with a regular expression. This makes the replacement more general and less prone to breakage if the variable assignment changes.