### PR TITLE
Feat/debug menu

### DIFF
--- a/logigator-editor-v2/src/app/actions/action-codec.ts
+++ b/logigator-editor-v2/src/app/actions/action-codec.ts
@@ -47,5 +47,12 @@ export function deserializeAction(dto: SerializedAction): Action {
       );
     case 'container':
       return new ActionContainer(...dto.actions.map(deserializeAction));
+    default:
+      // Unknown/future type from a malformed or newer dump: fail at parse time
+      // rather than leaking `undefined` into the restored stack (which would
+      // crash on the next undo/redo).
+      throw new Error(
+        `Unknown serialized action type: ${(dto as { type?: string }).type}`
+      );
   }
 }

--- a/logigator-editor-v2/src/app/actions/action-codec.ts
+++ b/logigator-editor-v2/src/app/actions/action-codec.ts
@@ -1,0 +1,51 @@
+import { Action } from './action';
+import { ActionContainer } from './action-container';
+import { SerializedAction } from './serialized-action.model';
+import { AddComponentsAction } from './actions/add-components.action';
+import { RemoveComponentsAction } from './actions/remove-components.action';
+import { AddWiresAction } from './actions/add-wires.action';
+import { RemoveWiresAction } from './actions/remove-wires.action';
+import { MoveComponentsAction } from './actions/move-components.action';
+import { MoveWiresAction } from './actions/move-wires.action';
+import { ChangeOptionAction } from './actions/change-option.action';
+import { TogglePortNegationAction } from './actions/toggle-port-negation.action';
+import { deserializeMoveEntries } from './actions/move-entry.model';
+
+/**
+ * Reconstructs an {@link Action} from its `Action.serialize()` output — the read
+ * side of the debug Project Dump format. The discriminated `type` maps back to a
+ * concrete action; `ReorderPlugsAction`/`UpdateInstanceAction` collapse to a
+ * plain {@link ActionContainer} (their behaviour is pure child delegation).
+ */
+export function deserializeAction(dto: SerializedAction): Action {
+  switch (dto.type) {
+    case 'addComponents':
+      return new AddComponentsAction(...dto.components);
+    case 'removeComponents':
+      return new RemoveComponentsAction(...dto.components);
+    case 'addWires':
+      return new AddWiresAction(...dto.wires);
+    case 'removeWires':
+      return new RemoveWiresAction(...dto.wires);
+    case 'moveComponents':
+      return new MoveComponentsAction(...deserializeMoveEntries(dto.entries));
+    case 'moveWires':
+      return new MoveWiresAction(...deserializeMoveEntries(dto.entries));
+    case 'changeOption':
+      return new ChangeOptionAction(
+        dto.componentId,
+        dto.optionKey,
+        dto.oldValue,
+        dto.newValue
+      );
+    case 'togglePortNegation':
+      return new TogglePortNegationAction(
+        dto.componentId,
+        dto.side,
+        dto.index,
+        dto.negated
+      );
+    case 'container':
+      return new ActionContainer(...dto.actions.map(deserializeAction));
+  }
+}

--- a/logigator-editor-v2/src/app/actions/action-container.ts
+++ b/logigator-editor-v2/src/app/actions/action-container.ts
@@ -1,5 +1,6 @@
 import { Action } from './action';
 import { Project } from '../project/project';
+import { SerializedAction } from './serialized-action.model';
 
 export class ActionContainer extends Action {
   private readonly actions: Action[];
@@ -7,6 +8,13 @@ export class ActionContainer extends Action {
   constructor(...actions: Action[]) {
     super();
     this.actions = actions;
+  }
+
+  public serialize(): SerializedAction {
+    return {
+      type: 'container',
+      actions: this.actions.map((action) => action.serialize())
+    };
   }
 
   public do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/action-manager.ts
+++ b/logigator-editor-v2/src/app/actions/action-manager.ts
@@ -60,6 +60,29 @@ export class ActionManager {
     this._pointer = 0;
   }
 
+  /** The recorded actions, oldest first. Read-only view for the debug dump. */
+  public get history(): readonly Action[] {
+    return this._history;
+  }
+
+  /** Index of the next redo (== number of done actions). For the debug dump. */
+  public get pointer(): number {
+    return this._pointer;
+  }
+
+  /**
+   * Replaces the history and pointer wholesale **without** re-applying any
+   * action — the project is expected to already hold the matching post-`do`
+   * state (debug Project Dump import loads the circuit body first, then restores
+   * this stack so undo/redo walks the real session history). The pointer is
+   * clamped into range.
+   */
+  public restore(history: Action[], pointer: number): void {
+    this._history = [...history];
+    this._pointer = Math.max(0, Math.min(pointer, this._history.length));
+    this._actionChange$.next();
+  }
+
   public get undoAvailable(): boolean {
     return this._pointer > 0;
   }

--- a/logigator-editor-v2/src/app/actions/action.ts
+++ b/logigator-editor-v2/src/app/actions/action.ts
@@ -1,6 +1,14 @@
 import { Project } from '../project/project';
+import { SerializedAction } from './serialized-action.model';
 
 export abstract class Action {
   abstract do(project: Project): void;
   abstract undo(project: Project): void;
+
+  /**
+   * JSON-safe snapshot of this action, used by the debug Project Dump feature
+   * to persist and restore the undo history. Reconstruct via `deserializeAction`
+   * (see `action-codec.ts`).
+   */
+  abstract serialize(): SerializedAction;
 }

--- a/logigator-editor-v2/src/app/actions/actions/add-components.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/add-components.action.ts
@@ -1,5 +1,6 @@
 import { Action } from '../action';
 import { SerializedComponent } from '../../components/serialized-component.model';
+import { SerializedAction } from '../serialized-action.model';
 import { Project } from '../../project/project';
 import { Component } from '../../components/component';
 import { getStaticDI } from '../../utils/get-di';
@@ -12,11 +13,21 @@ export class AddComponentsAction extends Action {
     ComponentProviderService
   );
 
-  constructor(...components: Component[]) {
+  constructor(...components: Component[]);
+  constructor(...components: SerializedComponent[]);
+  constructor(...components: Component[] | SerializedComponent[]) {
     super();
-    this._components = components.map((component) =>
-      Component.serialize(component)
-    );
+    if (components.length > 0 && components[0] instanceof Component) {
+      this._components = (components as Component[]).map((component) =>
+        Component.serialize(component)
+      );
+    } else {
+      this._components = components as SerializedComponent[];
+    }
+  }
+
+  serialize(): SerializedAction {
+    return { type: 'addComponents', components: this._components };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/actions/add-wires.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/add-wires.action.ts
@@ -2,6 +2,7 @@ import { Action } from '../action';
 import { Project } from '../../project/project';
 import { Wire } from '../../wires/wire';
 import { SerializedWire } from '../../wires/serialized-wire.model';
+import { SerializedAction } from '../serialized-action.model';
 
 export class AddWiresAction extends Action {
   private readonly _wires: SerializedWire[];
@@ -16,6 +17,10 @@ export class AddWiresAction extends Action {
     } else {
       this._wires = wires as SerializedWire[];
     }
+  }
+
+  serialize(): SerializedAction {
+    return { type: 'addWires', wires: this._wires };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/actions/change-option.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/change-option.action.ts
@@ -1,5 +1,6 @@
 import { Action } from '../action';
 import { Project } from '../../project/project';
+import { SerializedAction } from '../serialized-action.model';
 
 export class ChangeOptionAction<T = unknown> extends Action {
   constructor(
@@ -9,6 +10,16 @@ export class ChangeOptionAction<T = unknown> extends Action {
     private readonly newValue: T
   ) {
     super();
+  }
+
+  serialize(): SerializedAction {
+    return {
+      type: 'changeOption',
+      componentId: this.componentId,
+      optionKey: this.optionKey,
+      oldValue: this.oldValue,
+      newValue: this.newValue
+    };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/actions/move-components.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/move-components.action.ts
@@ -1,6 +1,7 @@
 import { Action } from '../action';
 import type { Project } from '../../project/project';
-import { MoveEntry } from './move-entry.model';
+import { MoveEntry, serializeMoveEntries } from './move-entry.model';
+import { SerializedAction } from '../serialized-action.model';
 
 export class MoveComponentsAction extends Action {
   private readonly _entries: MoveEntry[];
@@ -12,6 +13,13 @@ export class MoveComponentsAction extends Action {
       oldPos: e.oldPos.clone(),
       newPos: e.newPos.clone()
     }));
+  }
+
+  serialize(): SerializedAction {
+    return {
+      type: 'moveComponents',
+      entries: serializeMoveEntries(this._entries)
+    };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/actions/move-entry.model.ts
+++ b/logigator-editor-v2/src/app/actions/actions/move-entry.model.ts
@@ -1,7 +1,30 @@
 import { Point } from 'pixi.js';
+import { SerializedMoveEntry } from '../serialized-action.model';
 
 export interface MoveEntry {
   id: number;
   oldPos: Point;
   newPos: Point;
+}
+
+/** Flattens move entries' `Point`s to `[x, y]` pairs for the debug dump. */
+export function serializeMoveEntries(
+  entries: readonly MoveEntry[]
+): SerializedMoveEntry[] {
+  return entries.map((e) => ({
+    id: e.id,
+    oldPos: [e.oldPos.x, e.oldPos.y],
+    newPos: [e.newPos.x, e.newPos.y]
+  }));
+}
+
+/** Rebuilds move entries (with `Point`s) from their flattened dump form. */
+export function deserializeMoveEntries(
+  entries: readonly SerializedMoveEntry[]
+): MoveEntry[] {
+  return entries.map((e) => ({
+    id: e.id,
+    oldPos: new Point(e.oldPos[0], e.oldPos[1]),
+    newPos: new Point(e.newPos[0], e.newPos[1])
+  }));
 }

--- a/logigator-editor-v2/src/app/actions/actions/move-wires.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/move-wires.action.ts
@@ -1,6 +1,7 @@
 import { Action } from '../action';
 import type { Project } from '../../project/project';
-import { MoveEntry } from './move-entry.model';
+import { MoveEntry, serializeMoveEntries } from './move-entry.model';
+import { SerializedAction } from '../serialized-action.model';
 
 export class MoveWiresAction extends Action {
   private readonly _entries: MoveEntry[];
@@ -12,6 +13,10 @@ export class MoveWiresAction extends Action {
       oldPos: e.oldPos.clone(),
       newPos: e.newPos.clone()
     }));
+  }
+
+  serialize(): SerializedAction {
+    return { type: 'moveWires', entries: serializeMoveEntries(this._entries) };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/actions/remove-components.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/remove-components.action.ts
@@ -1,5 +1,6 @@
 import { Action } from '../action';
 import { SerializedComponent } from '../../components/serialized-component.model';
+import { SerializedAction } from '../serialized-action.model';
 import { Project } from '../../project/project';
 import { Component } from '../../components/component';
 import { getStaticDI } from '../../utils/get-di';
@@ -23,6 +24,10 @@ export class RemoveComponentsAction extends Action {
     } else {
       this._components = components as SerializedComponent[];
     }
+  }
+
+  serialize(): SerializedAction {
+    return { type: 'removeComponents', components: this._components };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/actions/remove-wires.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/remove-wires.action.ts
@@ -2,6 +2,7 @@ import { Action } from '../action';
 import { Project } from '../../project/project';
 import { Wire } from '../../wires/wire';
 import { SerializedWire } from '../../wires/serialized-wire.model';
+import { SerializedAction } from '../serialized-action.model';
 
 export class RemoveWiresAction extends Action {
   private readonly _wires: SerializedWire[];
@@ -16,6 +17,10 @@ export class RemoveWiresAction extends Action {
     } else {
       this._wires = wires as SerializedWire[];
     }
+  }
+
+  serialize(): SerializedAction {
+    return { type: 'removeWires', wires: this._wires };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/actions/toggle-port-negation.action.ts
+++ b/logigator-editor-v2/src/app/actions/actions/toggle-port-negation.action.ts
@@ -1,6 +1,7 @@
 import { Action } from '../action';
 import { Project } from '../../project/project';
 import { PortSide } from '../../components/component';
+import { SerializedAction } from '../serialized-action.model';
 
 /**
  * Toggles negation on a single component port. `negated` is the post-`do`
@@ -16,6 +17,16 @@ export class TogglePortNegationAction extends Action {
     private readonly negated: boolean
   ) {
     super();
+  }
+
+  serialize(): SerializedAction {
+    return {
+      type: 'togglePortNegation',
+      componentId: this.componentId,
+      side: this.side,
+      index: this.index,
+      negated: this.negated
+    };
   }
 
   do(project: Project): void {

--- a/logigator-editor-v2/src/app/actions/serialized-action.model.ts
+++ b/logigator-editor-v2/src/app/actions/serialized-action.model.ts
@@ -1,0 +1,43 @@
+import { SerializedComponent } from '../components/serialized-component.model';
+import { SerializedWire } from '../wires/serialized-wire.model';
+import { PortSide } from '../components/component';
+
+/** A {@link MoveEntry} with its `Point`s flattened to `[x, y]` for JSON. */
+export interface SerializedMoveEntry {
+  id: number;
+  oldPos: [number, number];
+  newPos: [number, number];
+}
+
+/**
+ * JSON-safe, discriminated representation of every {@link Action} subclass,
+ * produced by `Action.serialize()` and reconstructed by `deserializeAction`
+ * (see `action-codec.ts`). Used only by the debug Project Dump feature — it is
+ * not a persistence format for circuits.
+ *
+ * `ReorderPlugsAction`/`UpdateInstanceAction` extend `ActionContainer`, so they
+ * serialize as `container` and rehydrate as a plain container (their do/undo is
+ * pure child delegation, so behaviour is identical).
+ */
+export type SerializedAction =
+  | { type: 'addComponents'; components: SerializedComponent[] }
+  | { type: 'removeComponents'; components: SerializedComponent[] }
+  | { type: 'addWires'; wires: SerializedWire[] }
+  | { type: 'removeWires'; wires: SerializedWire[] }
+  | { type: 'moveComponents'; entries: SerializedMoveEntry[] }
+  | { type: 'moveWires'; entries: SerializedMoveEntry[] }
+  | {
+      type: 'changeOption';
+      componentId: number;
+      optionKey: string;
+      oldValue: unknown;
+      newValue: unknown;
+    }
+  | {
+      type: 'togglePortNegation';
+      componentId: number;
+      side: PortSide;
+      index: number;
+      negated: boolean;
+    }
+  | { type: 'container'; actions: SerializedAction[] };

--- a/logigator-editor-v2/src/app/persistence/dump/project-dump.types.ts
+++ b/logigator-editor-v2/src/app/persistence/dump/project-dump.types.ts
@@ -1,0 +1,28 @@
+import { SerializedAction } from '../../actions/serialized-action.model';
+
+/** Bumped if the dump envelope shape changes; the native circuit body inside
+ * `project` carries its own independent file version. */
+export const PROJECT_DUMP_VERSION = 1;
+
+/**
+ * Debug-only "Project Dump": a circuit plus everything needed to reconstruct the
+ * exact in-memory session it came from. Generated and re-imported from the debug
+ * menu (see `DebugMenuService`); never produced by normal save/export.
+ *
+ * `project` is a normal native circuit-file document — it loads just like a file
+ * import. Because that format drops element ids on load, `componentIds`/`wireIds`
+ * carry the original ids (parallel to the body's component/wire order) so they
+ * can be re-stamped, which keeps the id-referencing `actions` valid.
+ */
+export interface ProjectDump {
+  dumpVersion: number;
+  name: string;
+  /** A native circuit-file document (same shape as a `.json` export). */
+  project: unknown;
+  /** Original component ids, parallel to `project`'s component order. */
+  componentIds: number[];
+  /** Original wire ids, parallel to `project`'s wire order. */
+  wireIds: number[];
+  /** The undo history to restore, with the redo pointer's position. */
+  actions: { history: SerializedAction[]; pointer: number };
+}

--- a/logigator-editor-v2/src/app/persistence/persistence.service.spec.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.spec.ts
@@ -20,6 +20,8 @@ import { CustomComponentRegistry } from '../components/custom/custom-component-r
 import { ComponentProviderService } from '../components/component-provider.service';
 import { CustomComponent } from '../components/custom/custom-component';
 import { Component } from '../components/component';
+import { Point } from 'pixi.js';
+import { MoveComponentsAction } from '../actions/actions/move-components.action';
 import { SerializedCircuitBody } from './serialized-circuit';
 import {
   FakeBrowserComponentStore,
@@ -736,6 +738,84 @@ describe('PersistenceService', () => {
         service.importProjectFromJson('{not json')
       ).rejects.toThrowError(InvalidFileError);
       expect(browserStore.records.size).toBe(0);
+    });
+  });
+
+  describe('Project Dump', () => {
+    it('round-trips element ids and the undo history', async () => {
+      const source = await service.importProjectFromJson(
+        JSON.stringify({
+          version: 1,
+          name: 'Dumpee',
+          components: [
+            { type: 1, pos: [2, 3], options: {} },
+            { type: 1, pos: [5, 6], options: {} }
+          ],
+          wires: [{ pos: [0, 0], direction: 0, length: 4 }],
+          definitions: []
+        })
+      );
+
+      // Push a real action so the history is non-empty and the body reflects it.
+      const movedId = Array.from(source.components)[0].id;
+      source.actionManager.push(
+        new MoveComponentsAction({
+          id: movedId,
+          oldPos: new Point(2, 3),
+          newPos: new Point(9, 9)
+        })
+      );
+      const sourceComponentIds = Array.from(source.components).map((c) => c.id);
+      const sourceWireIds = Array.from(source.wires).map((w) => w.id);
+
+      const dumpJson = JSON.stringify(service.buildProjectDump(source));
+      const restored = await service.importProjectDump(dumpJson);
+
+      // Ids re-stamped exactly (the native format drops them on load).
+      expect(Array.from(restored.components).map((c) => c.id)).toEqual(
+        sourceComponentIds
+      );
+      expect(Array.from(restored.wires).map((w) => w.id)).toEqual(
+        sourceWireIds
+      );
+
+      // History + pointer restored without re-applying.
+      expect(restored.actionManager.history.length).toBe(1);
+      expect(restored.actionManager.pointer).toBe(1);
+
+      // The restored action targets the re-stamped element: the body shows the
+      // moved position, and undo reverts it.
+      const moved = restored.getComponentById(movedId)!;
+      expect([moved.position.x, moved.position.y]).toEqual([9, 9]);
+      restored.actionManager.undo();
+      expect([moved.position.x, moved.position.y]).toEqual([2, 3]);
+    });
+
+    it('skips id/history restore when the element count changed', async () => {
+      const source = await service.importProjectFromJson(
+        JSON.stringify({
+          version: 1,
+          name: 'Dumpee',
+          components: [{ type: 1, pos: [2, 3], options: {} }],
+          wires: [],
+          definitions: []
+        })
+      );
+      source.actionManager.push(
+        new MoveComponentsAction({
+          id: Array.from(source.components)[0].id,
+          oldPos: new Point(2, 3),
+          newPos: new Point(9, 9)
+        })
+      );
+
+      // Tamper with the saved id list so it no longer lines up with the body.
+      const dump = service.buildProjectDump(source);
+      dump.componentIds = [...dump.componentIds, 999];
+      const restored = await service.importProjectDump(JSON.stringify(dump));
+
+      expect(Array.from(restored.components).length).toBe(1);
+      expect(restored.actionManager.history.length).toBe(0);
     });
   });
 

--- a/logigator-editor-v2/src/app/persistence/persistence.service.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.ts
@@ -23,6 +23,7 @@ import { DefinitionBinding } from '../custom-component/definition-binding';
 import { buildProject, instantiateBody } from './circuit-builder';
 import { formatHttpError } from './persistence-errors';
 import { ServerPersistenceGateway } from './server/server-persistence.gateway';
+import { downloadBlob } from '../utils/download';
 
 export { AuthRequiredError } from './persistence-errors';
 
@@ -241,12 +242,7 @@ export class PersistenceService {
     const metadata = this.metadataStore.getMetadata(project);
     const name = metadata?.name ?? 'Untitled';
     const blob = new Blob([json], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${name}.json`;
-    link.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `${name}.json`);
   }
 
   /**

--- a/logigator-editor-v2/src/app/persistence/persistence.service.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.ts
@@ -24,6 +24,8 @@ import { buildProject, instantiateBody } from './circuit-builder';
 import { formatHttpError } from './persistence-errors';
 import { ServerPersistenceGateway } from './server/server-persistence.gateway';
 import { downloadBlob } from '../utils/download';
+import { ProjectDump, PROJECT_DUMP_VERSION } from './dump/project-dump.types';
+import { deserializeAction } from '../actions/action-codec';
 
 export { AuthRequiredError } from './persistence-errors';
 
@@ -257,7 +259,19 @@ export class PersistenceService {
   async importProjectFromJson(content: string): Promise<Project> {
     const { name, components, wires } = this.circuitFile.fromJson(content);
     const project = buildProject(components, wires);
+    await this._persistImportedProject(project, name);
+    return project;
+  }
 
+  /**
+   * Common tail of the import paths: adopts orphan custom snapshots, registers
+   * metadata, writes a fresh browser draft (so a reload restores it), then sets
+   * the project as main and navigates to `/local/:id`.
+   */
+  private async _persistImportedProject(
+    project: Project,
+    name: string
+  ): Promise<void> {
     // Adopt any imported custom that has no local master into the browser
     // components library, so the user can re-place it. (No stable cross-file
     // identity ⇒ re-importing the same file creates duplicate library rows.)
@@ -284,6 +298,75 @@ export class PersistenceService {
 
     this._replaceMainProject(project);
     this.location.go(`/local/${record.id}`);
+  }
+
+  /**
+   * Builds a debug {@link ProjectDump}: the native circuit document plus the
+   * original element ids (the format drops them on load) and the serialized undo
+   * history — enough to reconstruct the exact in-memory session.
+   */
+  buildProjectDump(project: Project): ProjectDump {
+    const name = this.metadataStore.getMetadata(project)?.name ?? 'Untitled';
+    const actionManager = project.actionManager;
+    return {
+      dumpVersion: PROJECT_DUMP_VERSION,
+      name,
+      project: JSON.parse(this.circuitFile.toJson(project, name)),
+      componentIds: [...project.components].map((c) => c.id),
+      wireIds: [...project.wires].map((w) => w.id),
+      actions: {
+        history: actionManager.history.map((a) => a.serialize()),
+        pointer: actionManager.pointer
+      }
+    };
+  }
+
+  /** Exports a {@link ProjectDump} as a downloadable `.dump.json` file. */
+  exportProjectDumpToFile(project: Project): void {
+    const dump = this.buildProjectDump(project);
+    const blob = new Blob([JSON.stringify(dump)], {
+      type: 'application/json'
+    });
+    downloadBlob(blob, `${dump.name}.dump.json`);
+  }
+
+  /**
+   * Imports a debug {@link ProjectDump}: loads the circuit body exactly like a
+   * file import, re-stamps the saved element ids onto the freshly-built
+   * instances, then restores the undo history so undo/redo walks the real
+   * session. If the loaded element count no longer matches the id lists (e.g. a
+   * custom dropped because its definition is missing), id and history restoration
+   * are skipped with a warning — the circuit still loads.
+   */
+  async importProjectDump(content: string): Promise<Project> {
+    const dump = JSON.parse(content) as ProjectDump;
+    if (!dump || typeof dump !== 'object' || dump.project === undefined) {
+      throw new Error('Not a Project Dump file');
+    }
+
+    const { name, components, wires } = this.circuitFile.decode(dump.project);
+
+    const idsMatch =
+      components.length === dump.componentIds?.length &&
+      wires.length === dump.wireIds?.length;
+    if (idsMatch) {
+      components.forEach((c, i) => (c.id = dump.componentIds[i]));
+      wires.forEach((w, i) => (w.id = dump.wireIds[i]));
+    } else {
+      this.toast.warn(
+        'Project Dump element count changed on load — ids and action history were not restored.'
+      );
+    }
+
+    const project = buildProject(components, wires);
+    await this._persistImportedProject(project, name);
+
+    if (idsMatch && dump.actions) {
+      project.actionManager.restore(
+        dump.actions.history.map(deserializeAction),
+        dump.actions.pointer
+      );
+    }
     return project;
   }
 

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -18,6 +18,7 @@ import { ComponentProviderService } from '../../components/component-provider.se
 import { deriveSummary } from '../../custom-component/definition-derivation';
 import { buildProject } from '../circuit-builder';
 import { AuthRequiredError, formatHttpError } from '../persistence-errors';
+import { BoardSnapshotService } from '../../rendering/board-snapshot.service';
 
 /**
  * Server transport + codec + metadata + build, returning `Project`s. Owns every
@@ -37,6 +38,7 @@ export class ServerPersistenceGateway {
   private readonly metadataStore = inject(ProjectMetadataStore);
   private readonly toast = inject(ToastService);
   private readonly logging = inject(LoggingService);
+  private readonly snapshot = inject(BoardSnapshotService);
 
   async loadProject(uuid: string): Promise<Project> {
     const detail = await firstValueFrom(this.projectApi.open(uuid));
@@ -151,6 +153,7 @@ export class ServerPersistenceGateway {
       this.metadataStore.clearDirty(project);
     }
     this.toast.success('Project saved');
+    void this._uploadPreview(project, response.id);
     return response.id;
   }
 
@@ -382,6 +385,7 @@ export class ServerPersistenceGateway {
         this.metadataStore.clearDirty(project);
       }
       this.toast.success('Project saved');
+      void this._uploadPreview(project, metadata.id);
     } catch (err) {
       if (this._isVersionMismatch(err)) {
         this.logging.error(
@@ -458,6 +462,29 @@ export class ServerPersistenceGateway {
         this.toast.error(`Save failed: ${formatHttpError(err)}`);
       }
       throw err;
+    }
+  }
+
+  /**
+   * Renders and uploads a project thumbnail after a successful server save.
+   * Fire-and-forget: a preview is a nice-to-have, so any failure is logged and
+   * swallowed rather than surfaced or allowed to fail the save. The backend
+   * requires two files (dark + light); we send the same current-theme render to
+   * both slots (see plans/image-export.md §8).
+   */
+  private async _uploadPreview(project: Project, projectId: string): Promise<void> {
+    try {
+      const blob = await this.snapshot.generatePreview(project);
+      if (!blob) return;
+      const formData = new FormData();
+      formData.append('previews', blob, 'preview.png');
+      formData.append('previews', blob, 'preview.png');
+      await firstValueFrom(this.projectApi.updatePreviews(projectId, formData));
+    } catch (err) {
+      this.logging.warn(
+        `Preview upload failed: ${formatHttpError(err)}`,
+        'ServerPersistenceGateway'
+      );
     }
   }
 

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -466,19 +466,19 @@ export class ServerPersistenceGateway {
   }
 
   /**
-   * Renders and uploads a project thumbnail after a successful server save.
-   * Fire-and-forget: a preview is a nice-to-have, so any failure is logged and
-   * swallowed rather than surfaced or allowed to fail the save. The backend
-   * requires two files (dark + light); we send the same current-theme render to
-   * both slots (see plans/image-export.md §8).
+   * Renders and uploads dark + light project thumbnails after a successful
+   * server save. Fire-and-forget: a preview is a nice-to-have, so any failure
+   * is logged and swallowed rather than surfaced or allowed to fail the save.
+   * Order matters — the backend maps `previews[0]` to the dark slot and
+   * `previews[1]` to the light slot.
    */
   private async _uploadPreview(project: Project, projectId: string): Promise<void> {
     try {
-      const blob = await this.snapshot.generatePreview(project);
-      if (!blob) return;
+      const previews = await this.snapshot.generatePreviews(project);
+      if (!previews) return;
       const formData = new FormData();
-      formData.append('previews', blob, 'preview.png');
-      formData.append('previews', blob, 'preview.png');
+      formData.append('previews', previews.dark, 'preview-dark.png');
+      formData.append('previews', previews.light, 'preview-light.png');
       await firstValueFrom(this.projectApi.updatePreviews(projectId, formData));
     } catch (err) {
       this.logging.warn(

--- a/logigator-editor-v2/src/app/project/project.spec.ts
+++ b/logigator-editor-v2/src/app/project/project.spec.ts
@@ -620,6 +620,52 @@ describe('Project.toggleConnectionAt', () => {
   });
 });
 
+describe('Project.getContentBounds', () => {
+  let project: Project;
+
+  beforeEach(() => {
+    configureTestBed();
+    project = new Project();
+  });
+
+  afterEach(() => {
+    project.destroy({ children: true });
+  });
+
+  it('returns null for an empty project', () => {
+    expect(project.getContentBounds()).toBeNull();
+  });
+
+  it('returns a single component’s gridBounds', () => {
+    const comp = makeAnd(2);
+    comp.position.set(3, 0);
+    project.addComponent(comp);
+
+    const b = project.getContentBounds()!;
+    const g = comp.gridBounds;
+    expect(b.x).toBeCloseTo(g.x);
+    expect(b.y).toBeCloseTo(g.y);
+    expect(b.right).toBeCloseTo(g.right);
+    expect(b.bottom).toBeCloseTo(g.bottom);
+  });
+
+  it('unions components and wires across the board', () => {
+    // AND at (3,0): gridBounds x∈[2.5,5.5], y∈[0,2]
+    const comp = makeAnd(2);
+    comp.position.set(3, 0);
+    project.addComponent(comp);
+    // Vertical wire at (2,5): gridBounds x∈[2,3], y∈[5,10]
+    const wire = makeWire(2, 5, WireDirection.VERTICAL, 4);
+    project.addWire(wire);
+
+    const b = project.getContentBounds()!;
+    expect(b.x).toBeCloseTo(2); // wire left edge
+    expect(b.y).toBeCloseTo(0); // component top
+    expect(b.right).toBeCloseTo(5.5); // component output stub tip
+    expect(b.bottom).toBeCloseTo(10); // wire bottom
+  });
+});
+
 describe('Project portsChange$ rebucket', () => {
   let project: Project;
 

--- a/logigator-editor-v2/src/app/project/project.ts
+++ b/logigator-editor-v2/src/app/project/project.ts
@@ -117,8 +117,12 @@ export class Project extends InteractionContainer {
    * Re-fetches every theme-dependent GraphicsContext after a theme change. The
    * cache is theme-keyed, so redrawing each element picks up the new colors.
    * Runs once on construction (a no-op on the still-empty scene).
+   *
+   * @param triggerRender request an on-screen frame after redrawing. Pass
+   * `false` when redrawing only to feed an offscreen snapshot (dual-theme
+   * previews), so the live canvas isn't repainted in the temporary theme.
    */
-  public applyTheme(): void {
+  public applyTheme(triggerRender = true): void {
     this._grid.redraw();
     for (const component of this._components.items) {
       component.redraw();
@@ -134,7 +138,7 @@ export class Project extends InteractionContainer {
     // (component/wire tint lives on the object and survives redraw). Re-apply it
     // to the new CPs. Selected components and wires keep their own tint.
     this.selectionManager.retintCps();
-    this._ticker$.next('single');
+    if (triggerRender) this._ticker$.next('single');
   }
 
   public get gridSpace(): Container {

--- a/logigator-editor-v2/src/app/project/project.ts
+++ b/logigator-editor-v2/src/app/project/project.ts
@@ -208,6 +208,39 @@ export class Project extends InteractionContainer {
     return this._wires.items;
   }
 
+  /**
+   * Tight axis-aligned bounds (grid units) covering all committed content
+   * (components incl. port stubs + wires), or `null` when the project is empty.
+   * Pure arithmetic over each element's `gridBounds` — no render-bounds
+   * traversal — and run once per snapshot, so the O(n) cost is negligible.
+   * Transient overlays are excluded.
+   */
+  public getContentBounds(): Rectangle | null {
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    const fold = (b: Rectangle): void => {
+      if (b.x < minX) minX = b.x;
+      if (b.y < minY) minY = b.y;
+      if (b.right > maxX) maxX = b.right;
+      if (b.bottom > maxY) maxY = b.bottom;
+    };
+    for (const component of this._components.items) fold(component.gridBounds);
+    for (const wire of this._wires.items) fold(wire.gridBounds);
+    if (!Number.isFinite(minX)) return null;
+    return new Rectangle(minX, minY, maxX - minX, maxY - minY);
+  }
+
+  /**
+   * Toggles the transient overlay (drag ghosts, wire preview, paste ghosts) so
+   * an offscreen snapshot captures only committed circuit content. The snapshot
+   * renders {@link gridSpace}, which contains this overlay as a child.
+   */
+  public setOverlayVisible(visible: boolean): void {
+    this._floatingLayer.renderable = visible;
+  }
+
   public get cursorPosition$(): Observable<Point> {
     return this._cursorPosition$.asObservable();
   }

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
@@ -6,6 +6,7 @@ import { Project } from '../project/project';
 import { makeAnd } from '../../testing/factories';
 import { BoardSnapshotService } from './board-snapshot.service';
 import { RendererHandleService } from './renderer-handle.service';
+import { ThemingService } from '../theming/theming.service';
 
 interface RenderCall {
   transform: { a: number; d: number; tx: number; ty: number };
@@ -139,20 +140,44 @@ describe('BoardSnapshotService', () => {
     texture.destroy(true);
   });
 
-  it('generatePreview returns null without a renderer', async () => {
+  it('generatePreviews returns null without a renderer', async () => {
     TestBed.inject(RendererHandleService).set(null);
-    expect(await service.generatePreview(project, 512)).toBeNull();
+    expect(await service.generatePreviews(project, 512)).toBeNull();
   });
 
-  it('generatePreview fits the longest side to the requested size', async () => {
+  it('generatePreviews renders both themes, fits the size, and restores the theme', async () => {
     const comp = makeAnd(2);
     comp.position.set(0, 0);
     project.addComponent(comp);
+    const theming = TestBed.inject(ThemingService);
+    const original = theming.currentThemeType();
 
-    const blob = await service.generatePreview(project, 512);
-    expect(blob).not.toBeNull();
-    const target = renderCalls.at(-1)!.target;
-    expect(Math.max(target.width, target.height)).toBe(512);
+    const previews = await service.generatePreviews(project, 512);
+
+    expect(previews).not.toBeNull();
+    expect(previews!.dark).toBeInstanceOf(Blob);
+    expect(previews!.light).toBeInstanceOf(Blob);
+    // One render call per theme, each fit to 512 on the longest side.
+    const sized = renderCalls.filter(
+      (c) => Math.max(c.target.width, c.target.height) === 512
+    );
+    expect(sized.length).toBe(2);
+    // Both themes were visited and the original restored.
+    expect(theming.currentThemeType()).toBe(original);
+  });
+
+  it('generatePreviews restores the theme even if rendering throws', async () => {
+    const comp = makeAnd(2);
+    comp.position.set(0, 0);
+    project.addComponent(comp);
+    const theming = TestBed.inject(ThemingService);
+    const original = theming.currentThemeType();
+    vi.spyOn(project, 'applyTheme').mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+
+    await expect(service.generatePreviews(project, 512)).rejects.toThrow();
+    expect(theming.currentThemeType()).toBe(original);
   });
 
   it('restores overlay visibility after rendering', () => {

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
@@ -104,7 +104,7 @@ describe('BoardSnapshotService', () => {
     texture.destroy(true);
   });
 
-  it('re-tunes content scale to the multiplier and restores it afterwards', () => {
+  it('renders at the reference scale (not the multiplier) and restores live scale', () => {
     const comp = makeAnd(2);
     comp.position.set(0, 0);
     project.addComponent(comp);
@@ -116,7 +116,8 @@ describe('BoardSnapshotService', () => {
     });
 
     const scales = spy.mock.calls.map((c) => c[0]);
-    expect(scales).toContain(3); // export scale applied
+    expect(scales).toContain(1); // reference scale → proportional line weights
+    expect(scales).not.toContain(3); // not scaled by the multiplier
     expect(scales.at(-1)).toBe(project.scale.x); // restored to live scale last
     texture.destroy(true);
   });

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
@@ -25,7 +25,13 @@ describe('BoardSnapshotService', () => {
 
     renderCalls = [];
     const renderer = {
-      render: vi.fn((opts: RenderCall) => renderCalls.push(opts))
+      render: vi.fn((opts: RenderCall) => renderCalls.push(opts)),
+      extract: {
+        canvas: () =>
+          ({
+            toBlob: (cb: BlobCallback) => cb(new Blob(['x']))
+          }) as unknown as HTMLCanvasElement
+      }
     } as unknown as Renderer;
     TestBed.inject(RendererHandleService).set(renderer);
     service = TestBed.inject(BoardSnapshotService);
@@ -113,6 +119,22 @@ describe('BoardSnapshotService', () => {
     expect(scales).toContain(3); // export scale applied
     expect(scales.at(-1)).toBe(project.scale.x); // restored to live scale last
     texture.destroy(true);
+  });
+
+  it('generatePreview returns null without a renderer', async () => {
+    TestBed.inject(RendererHandleService).set(null);
+    expect(await service.generatePreview(project, 512)).toBeNull();
+  });
+
+  it('generatePreview fits the longest side to the requested size', async () => {
+    const comp = makeAnd(2);
+    comp.position.set(0, 0);
+    project.addComponent(comp);
+
+    const blob = await service.generatePreview(project, 512);
+    expect(blob).not.toBeNull();
+    const target = renderCalls.at(-1)!.target;
+    expect(Math.max(target.width, target.height)).toBe(512);
   });
 
   it('restores overlay visibility after rendering', () => {

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
@@ -98,6 +98,23 @@ describe('BoardSnapshotService', () => {
     texture.destroy(true);
   });
 
+  it('re-tunes content scale to the multiplier and restores it afterwards', () => {
+    const comp = makeAnd(2);
+    comp.position.set(0, 0);
+    project.addComponent(comp);
+    const spy = vi.spyOn(comp, 'applyScale');
+
+    const texture = service.renderProjectToTexture(project, {
+      multiplier: 3,
+      background: 'solid'
+    });
+
+    const scales = spy.mock.calls.map((c) => c[0]);
+    expect(scales).toContain(3); // export scale applied
+    expect(scales.at(-1)).toBe(project.scale.x); // restored to live scale last
+    texture.destroy(true);
+  });
+
   it('restores overlay visibility after rendering', () => {
     const spy = vi.spyOn(project, 'setOverlayVisible');
     const texture = service.renderProjectToTexture(project, {

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Renderer, RenderTexture } from 'pixi.js';
+import { TestBed } from '@angular/core/testing';
+import { configureTestBed } from '../../testing/configure-test-bed';
+import { Project } from '../project/project';
+import { makeAnd } from '../../testing/factories';
+import { BoardSnapshotService } from './board-snapshot.service';
+import { RendererHandleService } from './renderer-handle.service';
+
+interface RenderCall {
+  transform: { a: number; d: number; tx: number; ty: number };
+  target: RenderTexture;
+  clear: boolean;
+  clearColor: unknown;
+}
+
+describe('BoardSnapshotService', () => {
+  let project: Project;
+  let service: BoardSnapshotService;
+  let renderCalls: RenderCall[];
+
+  beforeEach(() => {
+    configureTestBed();
+    project = new Project();
+
+    renderCalls = [];
+    const renderer = {
+      render: vi.fn((opts: RenderCall) => renderCalls.push(opts))
+    } as unknown as Renderer;
+    TestBed.inject(RendererHandleService).set(renderer);
+    service = TestBed.inject(BoardSnapshotService);
+  });
+
+  afterEach(() => {
+    project.destroy({ children: true });
+  });
+
+  it('reports availability from the renderer handle', () => {
+    expect(service.available).toBe(true);
+    TestBed.inject(RendererHandleService).set(null);
+    expect(service.available).toBe(false);
+  });
+
+  it('sizes the texture to content bounds + margin × multiplier', () => {
+    // AND at (3,0): gridBounds x∈[2.5,5.5], y∈[0,2]. Margin 1 → region (1.5,-1,5,4).
+    const comp = makeAnd(2);
+    comp.position.set(3, 0);
+    project.addComponent(comp);
+
+    const texture = service.renderProjectToTexture(project, {
+      multiplier: 2,
+      background: 'transparent'
+    });
+
+    // gridSize 16 × multiplier 2 = 32 px per grid unit.
+    expect(texture.width).toBe(160); // 5 × 32
+    expect(texture.height).toBe(128); // 4 × 32
+
+    const content = renderCalls.at(-1)!;
+    expect(content.transform.a).toBeCloseTo(32);
+    expect(content.transform.d).toBeCloseTo(32);
+    expect(content.transform.tx).toBeCloseTo(-48); // -region.x(1.5) × 32
+    expect(content.transform.ty).toBeCloseTo(32); // -region.y(-1) × 32
+
+    texture.destroy(true);
+  });
+
+  it('falls back to a fixed box for an empty project', () => {
+    const texture = service.renderProjectToTexture(project, {
+      multiplier: 1,
+      background: 'transparent'
+    });
+    // Empty fallback 16×16 + margin 1 each side → 18 grid units × gridSize 16.
+    expect(texture.width).toBe(18 * 16);
+    expect(texture.height).toBe(18 * 16);
+    texture.destroy(true);
+  });
+
+  it('transparent background: one content pass, cleared with rgba 0', () => {
+    const texture = service.renderProjectToTexture(project, {
+      multiplier: 1,
+      background: 'transparent'
+    });
+    expect(renderCalls.length).toBe(1);
+    expect(renderCalls[0].clear).toBe(true);
+    expect(renderCalls[0].clearColor).toEqual([0, 0, 0, 0]);
+    texture.destroy(true);
+  });
+
+  it('grid background: a grid pass clears, then content draws over it', () => {
+    const texture = service.renderProjectToTexture(project, {
+      multiplier: 1,
+      background: 'grid'
+    });
+    expect(renderCalls.length).toBe(2);
+    expect(renderCalls[0].clear).toBe(true); // grid pass clears
+    expect(renderCalls[1].clear).toBe(false); // content composited over grid
+    texture.destroy(true);
+  });
+
+  it('restores overlay visibility after rendering', () => {
+    const spy = vi.spyOn(project, 'setOverlayVisible');
+    const texture = service.renderProjectToTexture(project, {
+      multiplier: 1,
+      background: 'solid'
+    });
+    expect(spy).toHaveBeenNthCalledWith(1, false);
+    expect(spy).toHaveBeenNthCalledWith(2, true);
+    texture.destroy(true);
+  });
+});

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
@@ -122,6 +122,23 @@ describe('BoardSnapshotService', () => {
     texture.destroy(true);
   });
 
+  it('floors line weights at the multiplier when below 1× so they stay visible', () => {
+    const comp = makeAnd(2);
+    comp.position.set(0, 0);
+    project.addComponent(comp);
+    const spy = vi.spyOn(comp, 'applyScale');
+
+    const texture = service.renderProjectToTexture(project, {
+      multiplier: 0.5,
+      background: 'solid'
+    });
+
+    // Below 1× the weight scale tracks the multiplier (min(1, 0.5) = 0.5),
+    // keeping strokes ~1× px rather than going sub-pixel.
+    expect(spy.mock.calls.map((c) => c[0])).toContain(0.5);
+    texture.destroy(true);
+  });
+
   it('generatePreview returns null without a renderer', async () => {
     TestBed.inject(RendererHandleService).set(null);
     expect(await service.generatePreview(project, 512)).toBeNull();

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.spec.ts
@@ -157,11 +157,15 @@ describe('BoardSnapshotService', () => {
     expect(previews).not.toBeNull();
     expect(previews!.dark).toBeInstanceOf(Blob);
     expect(previews!.light).toBeInstanceOf(Blob);
-    // One render call per theme, each fit to 512 on the longest side.
-    const sized = renderCalls.filter(
-      (c) => Math.max(c.target.width, c.target.height) === 512
+    // One render call per theme, each a transparent 512×512 square.
+    const squareTransparent = renderCalls.filter(
+      (c) =>
+        c.target.width === 512 &&
+        c.target.height === 512 &&
+        Array.isArray(c.clearColor) &&
+        (c.clearColor as number[]).every((v) => v === 0)
     );
-    expect(sized.length).toBe(2);
+    expect(squareTransparent.length).toBe(2);
     // Both themes were visited and the original restored.
     expect(theming.currentThemeType()).toBe(original);
   });

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -12,6 +12,7 @@ import { RendererHandleService } from './renderer-handle.service';
 import { GraphicsProviderService } from './graphics-provider.service';
 import { GridGraphics } from './graphics/grid.graphics';
 import { ThemingService } from '../theming/theming.service';
+import { ThemeType } from '../theming/theme-type.enum';
 import { Project } from '../project/project';
 import { environment } from '../../environments/environment';
 
@@ -120,23 +121,62 @@ export class BoardSnapshotService {
   }
 
   /**
-   * Renders a square-ish PNG preview of the project (longest side fit to
-   * `sizePx`) for server-side thumbnails. Uses a solid theme background for a
-   * clean thumbnail. Resolves `null` when no renderer is available so the save
-   * flow can skip the upload silently.
+   * Renders dark- and light-themed PNG previews of the project (longest side
+   * fit to `sizePx`) for server-side thumbnails, using a solid theme background.
+   * Resolves `null` when no renderer is available so the save flow can skip the
+   * upload silently.
+   *
+   * Theme colors are baked into cached graphics, so each theme is produced by
+   * briefly switching the global theme and redrawing the project (the same path
+   * a live theme toggle uses). All switching + offscreen rendering happens
+   * synchronously and the original theme is restored in a `finally` *before* the
+   * first `await`, so no wrong-theme frame can paint on the live canvas.
    */
-  public async generatePreview(
+  public async generatePreviews(
     project: Project,
     sizePx: number = PREVIEW_SIZE
-  ): Promise<Blob | null> {
+  ): Promise<{ dark: Blob; light: Blob } | null> {
     if (!this.available) return null;
+
+    const original = this.themingService.currentThemeType();
+    let darkCanvas!: HTMLCanvasElement;
+    let lightCanvas!: HTMLCanvasElement;
+    try {
+      darkCanvas = this._renderThemedPreview(project, ThemeType.DARK, sizePx);
+      lightCanvas = this._renderThemedPreview(project, ThemeType.LIGHT, sizePx);
+    } finally {
+      // Always restore the live theme, even if a render throws — the caller
+      // swallows errors, so a leaked theme switch would be silent and baffling.
+      this._applyThemeForRender(project, original);
+    }
+
+    const dark = await this._canvasToBlob(darkCanvas);
+    const light = await this._canvasToBlob(lightCanvas);
+    return dark && light ? { dark, light } : null;
+  }
+
+  private _renderThemedPreview(
+    project: Project,
+    theme: ThemeType,
+    sizePx: number
+  ): HTMLCanvasElement {
+    this._applyThemeForRender(project, theme);
     const region = this.computeRegion(project);
     const longestUnits = Math.max(region.width, region.height);
     const multiplier = sizePx / (longestUnits * environment.gridSize);
-    const canvas = this.renderProjectToCanvas(project, {
+    return this.renderRegionToCanvas(project, region, {
       multiplier,
       background: 'solid'
     });
+  }
+
+  /** Switches the global theme and redraws the project without a screen tick. */
+  private _applyThemeForRender(project: Project, theme: ThemeType): void {
+    this.themingService.setActiveThemeType(theme);
+    project.applyTheme(false);
+  }
+
+  private _canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
     return new Promise((resolve) =>
       canvas.toBlob((blob) => resolve(blob), 'image/png')
     );

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -54,24 +54,79 @@ export class BoardSnapshotService {
   }
 
   /**
-   * Renders a project's tight content bounds (plus a margin) into a texture,
-   * falling back to a small fixed box for empty projects.
+   * The region (grid units) a full-project snapshot covers: tight content
+   * bounds plus a margin, or a small fixed box when the project is empty.
+   */
+  public computeRegion(
+    project: Project,
+    marginGrid: number = EXPORT_MARGIN_GRID
+  ): Rectangle {
+    const content =
+      project.getContentBounds() ??
+      new Rectangle(0, 0, EMPTY_FALLBACK_GRID, EMPTY_FALLBACK_GRID);
+    return new Rectangle(
+      content.x - marginGrid,
+      content.y - marginGrid,
+      content.width + 2 * marginGrid,
+      content.height + 2 * marginGrid
+    );
+  }
+
+  /** Output pixel dimensions for a region at a multiplier. */
+  public outputSize(
+    region: Rectangle,
+    multiplier: number
+  ): { width: number; height: number } {
+    const pxPerUnit = environment.gridSize * multiplier;
+    return {
+      width: Math.max(1, Math.round(region.width * pxPerUnit)),
+      height: Math.max(1, Math.round(region.height * pxPerUnit))
+    };
+  }
+
+  /**
+   * Renders a project's content (tight bounds + margin, or empty fallback) into
+   * a texture. Caller owns the returned texture.
    */
   public renderProjectToTexture(
     project: Project,
     options: SnapshotOptions
   ): RenderTexture {
-    const margin = options.marginGrid ?? EXPORT_MARGIN_GRID;
-    const content =
-      project.getContentBounds() ??
-      new Rectangle(0, 0, EMPTY_FALLBACK_GRID, EMPTY_FALLBACK_GRID);
-    const region = new Rectangle(
-      content.x - margin,
-      content.y - margin,
-      content.width + 2 * margin,
-      content.height + 2 * margin
-    );
+    const region = this.computeRegion(project, options.marginGrid);
     return this.renderRegionToTexture(project, region, options);
+  }
+
+  /**
+   * Renders a project's content into an `HTMLCanvasElement` (extracted from the
+   * texture). The texture is destroyed before returning; the canvas is a
+   * standalone copy.
+   */
+  public renderProjectToCanvas(
+    project: Project,
+    options: SnapshotOptions
+  ): HTMLCanvasElement {
+    const region = this.computeRegion(project, options.marginGrid);
+    return this.renderRegionToCanvas(project, region, options);
+  }
+
+  /** Renders a region into an `HTMLCanvasElement`. See {@link renderProjectToCanvas}. */
+  public renderRegionToCanvas(
+    project: Project,
+    region: Rectangle,
+    options: SnapshotOptions
+  ): HTMLCanvasElement {
+    const renderer = this.rendererHandle.renderer;
+    if (!renderer) {
+      throw new Error('BoardSnapshotService: no renderer registered');
+    }
+    const texture = this.renderRegionToTexture(project, region, options);
+    try {
+      return renderer.extract.canvas({
+        target: texture
+      }) as HTMLCanvasElement;
+    } finally {
+      texture.destroy(true);
+    }
   }
 
   /**
@@ -92,8 +147,7 @@ export class BoardSnapshotService {
 
     const gridSize = environment.gridSize;
     const pxPerUnit = gridSize * options.multiplier;
-    const width = Math.max(1, Math.round(region.width * pxPerUnit));
-    const height = Math.max(1, Math.round(region.height * pxPerUnit));
+    const { width, height } = this.outputSize(region, options.multiplier);
 
     const texture = RenderTexture.create({
       width,

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -195,6 +195,13 @@ export class BoardSnapshotService {
     // visible; the next on-screen frame re-culls against the live viewport.
     this._uncull(project.gridSpace);
     project.setOverlayVisible(false);
+
+    // Scale-dependent visuals (screen-constant strokes, Text glyph resolution)
+    // are tuned to the live zoom. Re-tune them to the export scale so line
+    // weights are zoom-independent and text stays crisp at high multipliers,
+    // then restore. No flicker: nothing renders on-screen between the calls.
+    const liveScale = project.scale.x;
+    this._applyContentScale(project, options.multiplier);
     try {
       renderer.render({
         container: project.gridSpace,
@@ -205,6 +212,7 @@ export class BoardSnapshotService {
         clear: !withGrid
       });
     } finally {
+      this._applyContentScale(project, liveScale);
       project.setOverlayVisible(true);
       grid?.destroy({ children: true });
     }
@@ -238,6 +246,13 @@ export class BoardSnapshotService {
       }
     }
     return container;
+  }
+
+  /** Re-tunes every content element's scale-dependent visuals (see `applyScale`). */
+  private _applyContentScale(project: Project, scale: number): void {
+    for (const component of project.components) component.applyScale(scale);
+    for (const wire of project.wires) wire.applyScale(scale);
+    project.connectionPoints.layer.applyScale(scale);
   }
 
   private _uncull(container: Container): void {

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -29,6 +29,8 @@ export interface SnapshotOptions {
 export const EXPORT_MARGIN_GRID = 1;
 /** Fallback content box (grid units) used when the project is empty. */
 export const EMPTY_FALLBACK_GRID = 16;
+/** Default edge length (px) of a server-save preview. */
+export const PREVIEW_SIZE = 1024;
 /** Grid units per export-grid chunk; matches the live {@link Grid}. */
 const GRID_CHUNK = 32;
 
@@ -107,6 +109,29 @@ export class BoardSnapshotService {
   ): HTMLCanvasElement {
     const region = this.computeRegion(project, options.marginGrid);
     return this.renderRegionToCanvas(project, region, options);
+  }
+
+  /**
+   * Renders a square-ish PNG preview of the project (longest side fit to
+   * `sizePx`) for server-side thumbnails. Uses a solid theme background for a
+   * clean thumbnail. Resolves `null` when no renderer is available so the save
+   * flow can skip the upload silently.
+   */
+  public async generatePreview(
+    project: Project,
+    sizePx: number = PREVIEW_SIZE
+  ): Promise<Blob | null> {
+    if (!this.available) return null;
+    const region = this.computeRegion(project);
+    const longestUnits = Math.max(region.width, region.height);
+    const multiplier = sizePx / (longestUnits * environment.gridSize);
+    const canvas = this.renderProjectToCanvas(project, {
+      multiplier,
+      background: 'solid'
+    });
+    return new Promise((resolve) =>
+      canvas.toBlob((blob) => resolve(blob), 'image/png')
+    );
   }
 
   /** Renders a region into an `HTMLCanvasElement`. See {@link renderProjectToCanvas}. */

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -5,6 +5,7 @@ import {
   Matrix,
   Rectangle,
   RenderTexture,
+  Text,
   type ColorSource
 } from 'pixi.js';
 import { RendererHandleService } from './renderer-handle.service';
@@ -33,6 +34,13 @@ export const EMPTY_FALLBACK_GRID = 16;
 export const PREVIEW_SIZE = 1024;
 /** Grid units per export-grid chunk; matches the live {@link Grid}. */
 const GRID_CHUNK = 32;
+/**
+ * The "100% zoom" scale the export renders content at. Decoupling the export
+ * from the live zoom keeps it deterministic, and rendering at scale 1 lets the
+ * output matrix scale line weights and grid dots up proportionally with the
+ * multiplier instead of holding them screen-constant.
+ */
+const REFERENCE_SCALE = 1;
 
 /**
  * Renders a project's content into an offscreen `RenderTexture`. The reusable
@@ -194,8 +202,9 @@ export class BoardSnapshotService {
     let grid: Container | null = null;
     if (withGrid) {
       // The export grid is authored in project-pixel space (gridSize px per
-      // grid unit), so it scales by the multiplier only.
-      grid = this._buildGrid(region, options.multiplier);
+      // grid unit) at the 100%-reference scale, so the matrix scales it by the
+      // multiplier — dot size and spacing both grow with the multiplier.
+      grid = this._buildGrid(region);
       const gridMatrix = new Matrix()
         .scale(options.multiplier, options.multiplier)
         .translate(tx, ty);
@@ -221,12 +230,18 @@ export class BoardSnapshotService {
     this._uncull(project.gridSpace);
     project.setOverlayVisible(false);
 
-    // Scale-dependent visuals (screen-constant strokes, Text glyph resolution)
-    // are tuned to the live zoom. Re-tune them to the export scale so line
-    // weights are zoom-independent and text stays crisp at high multipliers,
-    // then restore. No flicker: nothing renders on-screen between the calls.
+    // Render the content at the 100%-reference scale (REFERENCE_SCALE),
+    // independent of the live zoom, so the export matches the natural look and
+    // the matrix scales line weights / grid dots up *proportionally* with the
+    // multiplier (a higher resolution is the same picture with more pixels, not
+    // thinner lines). Text is a pre-rasterized texture, so its glyph resolution
+    // is bumped to the multiplier separately to stay crisp. Everything is
+    // restored afterwards — no flicker, since nothing renders on-screen between.
     const liveScale = project.scale.x;
-    this._applyContentScale(project, options.multiplier);
+    const texts = this._collectTexts(project.gridSpace);
+    const textResolutions = texts.map((t) => t.resolution);
+    this._applyContentScale(project, REFERENCE_SCALE);
+    for (const text of texts) text.resolution = options.multiplier;
     try {
       renderer.render({
         container: project.gridSpace,
@@ -238,6 +253,7 @@ export class BoardSnapshotService {
       });
     } finally {
       this._applyContentScale(project, liveScale);
+      texts.forEach((text, i) => (text.resolution = textResolutions[i]));
       project.setOverlayVisible(true);
       grid?.destroy({ children: true });
     }
@@ -251,12 +267,12 @@ export class BoardSnapshotService {
    * context, so even a large region stays cheap. Chunks overhanging the region
    * are clipped by the texture bounds.
    */
-  private _buildGrid(region: Rectangle, multiplier: number): Container {
+  private _buildGrid(region: Rectangle): Container {
     const gridSize = environment.gridSize;
     const context = this.graphicsProvider.getGraphicsContext(
       GridGraphics,
       GRID_CHUNK,
-      multiplier
+      REFERENCE_SCALE
     );
     const container = new Container();
     const startX = Math.floor(region.x / GRID_CHUNK) * GRID_CHUNK;
@@ -278,6 +294,17 @@ export class BoardSnapshotService {
     for (const component of project.components) component.applyScale(scale);
     for (const wire of project.wires) wire.applyScale(scale);
     project.connectionPoints.layer.applyScale(scale);
+  }
+
+  /** Collects every `Text` node under a container (for glyph-resolution tuning). */
+  private _collectTexts(container: Container): Text[] {
+    const out: Text[] = [];
+    const visit = (node: Container): void => {
+      if (node instanceof Text) out.push(node);
+      for (const child of node.children) visit(child as Container);
+    };
+    visit(container);
+    return out;
   }
 
   private _uncull(container: Container): void {

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -182,6 +182,13 @@ export class BoardSnapshotService {
     const pxPerUnit = gridSize * options.multiplier;
     const { width, height } = this.outputSize(region, options.multiplier);
 
+    // Scale that drives line weights / grid-dot sizes. Capped at the 100%
+    // reference so weights grow proportionally for multipliers ≥ 1, but for
+    // multipliers < 1 (capped huge boards, previews) it tracks the multiplier
+    // so strokes and dots never render thinner than they do at 100% zoom —
+    // otherwise they go sub-pixel and the thumbnail washes out.
+    const lineScale = Math.min(REFERENCE_SCALE, options.multiplier);
+
     const texture = RenderTexture.create({
       width,
       height,
@@ -201,10 +208,10 @@ export class BoardSnapshotService {
 
     let grid: Container | null = null;
     if (withGrid) {
-      // The export grid is authored in project-pixel space (gridSize px per
-      // grid unit) at the 100%-reference scale, so the matrix scales it by the
-      // multiplier — dot size and spacing both grow with the multiplier.
-      grid = this._buildGrid(region);
+      // Dots authored at `lineScale` (project-pixel space); the matrix scales
+      // them by the multiplier. Spacing always grows with the multiplier; dot
+      // size grows for multipliers ≥ 1 and is floored at ~1px below that.
+      grid = this._buildGrid(region, lineScale);
       const gridMatrix = new Matrix()
         .scale(options.multiplier, options.multiplier)
         .translate(tx, ty);
@@ -230,17 +237,18 @@ export class BoardSnapshotService {
     this._uncull(project.gridSpace);
     project.setOverlayVisible(false);
 
-    // Render the content at the 100%-reference scale (REFERENCE_SCALE),
-    // independent of the live zoom, so the export matches the natural look and
-    // the matrix scales line weights / grid dots up *proportionally* with the
-    // multiplier (a higher resolution is the same picture with more pixels, not
-    // thinner lines). Text is a pre-rasterized texture, so its glyph resolution
-    // is bumped to the multiplier separately to stay crisp. Everything is
-    // restored afterwards — no flicker, since nothing renders on-screen between.
+    // Render the content at `lineScale`, independent of the live zoom, so the
+    // export matches the natural look: the matrix scales line weights up
+    // proportionally with the multiplier (higher resolution = the same picture
+    // with more pixels, not thinner lines) while the `lineScale` floor keeps
+    // them visible below 1×. Text is a pre-rasterized texture, so its glyph
+    // resolution is bumped to the multiplier separately to stay crisp.
+    // Everything is restored afterwards — no flicker, nothing renders on-screen
+    // between the calls.
     const liveScale = project.scale.x;
     const texts = this._collectTexts(project.gridSpace);
     const textResolutions = texts.map((t) => t.resolution);
-    this._applyContentScale(project, REFERENCE_SCALE);
+    this._applyContentScale(project, lineScale);
     for (const text of texts) text.resolution = options.multiplier;
     try {
       renderer.render({
@@ -267,12 +275,12 @@ export class BoardSnapshotService {
    * context, so even a large region stays cheap. Chunks overhanging the region
    * are clipped by the texture bounds.
    */
-  private _buildGrid(region: Rectangle): Container {
+  private _buildGrid(region: Rectangle, lineScale: number): Container {
     const gridSize = environment.gridSize;
     const context = this.graphicsProvider.getGraphicsContext(
       GridGraphics,
       GRID_CHUNK,
-      REFERENCE_SCALE
+      lineScale
     );
     const container = new Container();
     const startX = Math.floor(region.x / GRID_CHUNK) * GRID_CHUNK;

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -1,0 +1,195 @@
+import { inject, Injectable } from '@angular/core';
+import {
+  Container,
+  Graphics,
+  Matrix,
+  Rectangle,
+  RenderTexture,
+  type ColorSource
+} from 'pixi.js';
+import { RendererHandleService } from './renderer-handle.service';
+import { GraphicsProviderService } from './graphics-provider.service';
+import { GridGraphics } from './graphics/grid.graphics';
+import { ThemingService } from '../theming/theming.service';
+import { Project } from '../project/project';
+import { environment } from '../../environments/environment';
+
+export type SnapshotBackground = 'grid' | 'solid' | 'transparent';
+
+export interface SnapshotOptions {
+  /** Output pixels per grid unit = `gridSize × multiplier`. */
+  multiplier: number;
+  /** `grid` = theme color + dot-grid, `solid` = theme color, `transparent`. */
+  background: SnapshotBackground;
+  /** Margin around content, in grid units. Defaults to {@link EXPORT_MARGIN_GRID}. */
+  marginGrid?: number;
+}
+
+/** Margin kept around the content bounds in a full-project snapshot. */
+export const EXPORT_MARGIN_GRID = 1;
+/** Fallback content box (grid units) used when the project is empty. */
+export const EMPTY_FALLBACK_GRID = 16;
+/** Grid units per export-grid chunk; matches the live {@link Grid}. */
+const GRID_CHUNK = 32;
+
+/**
+ * Renders a project's content into an offscreen `RenderTexture`. The reusable
+ * primitive behind image export, server previews and (later) a minimap: it
+ * renders the *real* scene graph, so every component type — including ROM and
+ * flattened custom components — is covered without any per-type code.
+ *
+ * Callers own the returned texture and must destroy it (`texture.destroy(true)`).
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class BoardSnapshotService {
+  private readonly rendererHandle = inject(RendererHandleService);
+  private readonly graphicsProvider = inject(GraphicsProviderService);
+  private readonly themingService = inject(ThemingService);
+
+  /** Whether a renderer is registered (false before the board has loaded). */
+  public get available(): boolean {
+    return this.rendererHandle.available;
+  }
+
+  /**
+   * Renders a project's tight content bounds (plus a margin) into a texture,
+   * falling back to a small fixed box for empty projects.
+   */
+  public renderProjectToTexture(
+    project: Project,
+    options: SnapshotOptions
+  ): RenderTexture {
+    const margin = options.marginGrid ?? EXPORT_MARGIN_GRID;
+    const content =
+      project.getContentBounds() ??
+      new Rectangle(0, 0, EMPTY_FALLBACK_GRID, EMPTY_FALLBACK_GRID);
+    const region = new Rectangle(
+      content.x - margin,
+      content.y - margin,
+      content.width + 2 * margin,
+      content.height + 2 * margin
+    );
+    return this.renderRegionToTexture(project, region, options);
+  }
+
+  /**
+   * Renders an arbitrary region (grid units) of a project into a texture. A
+   * passed transform replaces the rendered container's own transform (see
+   * PixiJS `renderer.render`), so the matrices below bake in the `gridSize`
+   * scale that `gridSpace` would otherwise apply.
+   */
+  public renderRegionToTexture(
+    project: Project,
+    region: Rectangle,
+    options: SnapshotOptions
+  ): RenderTexture {
+    const renderer = this.rendererHandle.renderer;
+    if (!renderer) {
+      throw new Error('BoardSnapshotService: no renderer registered');
+    }
+
+    const gridSize = environment.gridSize;
+    const pxPerUnit = gridSize * options.multiplier;
+    const width = Math.max(1, Math.round(region.width * pxPerUnit));
+    const height = Math.max(1, Math.round(region.height * pxPerUnit));
+
+    const texture = RenderTexture.create({
+      width,
+      height,
+      resolution: 1,
+      antialias: true
+    });
+
+    // Shared translation (output px): the region's top-left maps to (0,0).
+    const tx = -region.x * pxPerUnit;
+    const ty = -region.y * pxPerUnit;
+
+    const transparent = options.background === 'transparent';
+    const clearColor: ColorSource = transparent
+      ? [0, 0, 0, 0]
+      : this.themingService.currentTheme().background;
+    const withGrid = options.background === 'grid';
+
+    let grid: Container | null = null;
+    if (withGrid) {
+      // The export grid is authored in project-pixel space (gridSize px per
+      // grid unit), so it scales by the multiplier only.
+      grid = this._buildGrid(region, options.multiplier);
+      const gridMatrix = new Matrix()
+        .scale(options.multiplier, options.multiplier)
+        .translate(tx, ty);
+      renderer.render({
+        container: grid,
+        transform: gridMatrix,
+        target: texture,
+        clearColor,
+        clear: true
+      });
+    }
+
+    // Content pass. gridSpace children sit in grid units, so scale by
+    // gridSize × multiplier.
+    const contentMatrix = new Matrix()
+      .scale(pxPerUnit, pxPerUnit)
+      .translate(tx, ty);
+
+    // The CullerPlugin only runs on the on-screen ticker render, never on a
+    // manual render-to-texture, so off-screen quad-tree entries keep last
+    // frame's `culled` bit and would be missing here. Force the content subtree
+    // visible; the next on-screen frame re-culls against the live viewport.
+    this._uncull(project.gridSpace);
+    project.setOverlayVisible(false);
+    try {
+      renderer.render({
+        container: project.gridSpace,
+        transform: contentMatrix,
+        target: texture,
+        clearColor,
+        // When a grid pass already cleared, draw the content over it.
+        clear: !withGrid
+      });
+    } finally {
+      project.setOverlayVisible(true);
+      grid?.destroy({ children: true });
+    }
+
+    return texture;
+  }
+
+  /**
+   * Tiles the cached, theme-keyed {@link GridGraphics} context over the region
+   * so the export grid matches the editor exactly. Every chunk shares one
+   * context, so even a large region stays cheap. Chunks overhanging the region
+   * are clipped by the texture bounds.
+   */
+  private _buildGrid(region: Rectangle, multiplier: number): Container {
+    const gridSize = environment.gridSize;
+    const context = this.graphicsProvider.getGraphicsContext(
+      GridGraphics,
+      GRID_CHUNK,
+      multiplier
+    );
+    const container = new Container();
+    const startX = Math.floor(region.x / GRID_CHUNK) * GRID_CHUNK;
+    const startY = Math.floor(region.y / GRID_CHUNK) * GRID_CHUNK;
+    const endX = region.x + region.width;
+    const endY = region.y + region.height;
+    for (let gx = startX; gx < endX; gx += GRID_CHUNK) {
+      for (let gy = startY; gy < endY; gy += GRID_CHUNK) {
+        const chunk = new Graphics(context);
+        chunk.position.set(gx * gridSize, gy * gridSize);
+        container.addChild(chunk);
+      }
+    }
+    return container;
+  }
+
+  private _uncull(container: Container): void {
+    container.culled = false;
+    for (const child of container.children) {
+      this._uncull(child as Container);
+    }
+  }
+}

--- a/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
+++ b/logigator-editor-v2/src/app/rendering/board-snapshot.service.ts
@@ -121,10 +121,10 @@ export class BoardSnapshotService {
   }
 
   /**
-   * Renders dark- and light-themed PNG previews of the project (longest side
-   * fit to `sizePx`) for server-side thumbnails, using a solid theme background.
-   * Resolves `null` when no renderer is available so the save flow can skip the
-   * upload silently.
+   * Renders dark- and light-themed PNG previews of the project for server-side
+   * thumbnails: a square `sizePx × sizePx` image with a **transparent**
+   * background and the content centered. Resolves `null` when no renderer is
+   * available so the save flow can skip the upload silently.
    *
    * Theme colors are baked into cached graphics, so each theme is produced by
    * briefly switching the global theme and redrawing the project (the same path
@@ -161,13 +161,23 @@ export class BoardSnapshotService {
     sizePx: number
   ): HTMLCanvasElement {
     this._applyThemeForRender(project, theme);
-    const region = this.computeRegion(project);
-    const longestUnits = Math.max(region.width, region.height);
-    const multiplier = sizePx / (longestUnits * environment.gridSize);
+    const region = this._squareRegion(this.computeRegion(project));
+    const multiplier = sizePx / (region.width * environment.gridSize);
     return this.renderRegionToCanvas(project, region, {
       multiplier,
-      background: 'solid'
+      background: 'transparent'
     });
+  }
+
+  /** Expands a region to a square centered on it (pads the shorter axis). */
+  private _squareRegion(region: Rectangle): Rectangle {
+    const side = Math.max(region.width, region.height);
+    return new Rectangle(
+      region.x - (side - region.width) / 2,
+      region.y - (side - region.height) / 2,
+      side,
+      side
+    );
   }
 
   /** Switches the global theme and redraws the project without a screen tick. */

--- a/logigator-editor-v2/src/app/rendering/image-export.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/image-export.service.spec.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { Rectangle } from 'pixi.js';
+import { TestBed } from '@angular/core/testing';
+import { configureTestBed } from '../../testing/configure-test-bed';
+import {
+  ImageExportService,
+  MAX_EXPORT_DIMENSION
+} from './image-export.service';
+import { BoardSnapshotService } from './board-snapshot.service';
+import { ProjectMetadataStore } from '../persistence/project-metadata.store';
+import { ToastService } from '../logging/toast.service';
+import { Project } from '../project/project';
+
+const GRID_SIZE = 16;
+
+function fakeCanvas(): HTMLCanvasElement {
+  return {
+    width: 10,
+    height: 10,
+    toBlob: (cb: BlobCallback) => cb(new Blob(['x']))
+  } as unknown as HTMLCanvasElement;
+}
+
+describe('ImageExportService', () => {
+  let service: ImageExportService;
+  let snapshot: {
+    available: boolean;
+    computeRegion: Mock;
+    outputSize: Mock;
+    renderProjectToCanvas: Mock;
+  };
+  let toast: { error: Mock; warn: Mock; success: Mock; info: Mock };
+  let downloads: string[];
+  let clickSpy: Mock;
+  const project = {} as unknown as Project;
+
+  function setup(region: Rectangle): void {
+    snapshot = {
+      available: true,
+      computeRegion: vi.fn(() => region),
+      outputSize: vi.fn((r: Rectangle, m: number) => ({
+        width: Math.round(r.width * GRID_SIZE * m),
+        height: Math.round(r.height * GRID_SIZE * m)
+      })),
+      renderProjectToCanvas: vi.fn(() => fakeCanvas())
+    };
+    toast = { error: vi.fn(), warn: vi.fn(), success: vi.fn(), info: vi.fn() };
+    configureTestBed([
+      { provide: BoardSnapshotService, useValue: snapshot },
+      {
+        provide: ProjectMetadataStore,
+        useValue: { getMetadata: () => ({ name: 'MyBoard' }) }
+      },
+      { provide: ToastService, useValue: toast }
+    ]);
+    service = TestBed.inject(ImageExportService);
+  }
+
+  beforeEach(() => {
+    downloads = [];
+    // jsdom/happy-dom don't implement object URLs; stub them and capture the
+    // download via the anchor's click rather than letting it navigate.
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:x');
+    globalThis.URL.revokeObjectURL = vi.fn();
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloads.push(this.download);
+      }) as unknown as Mock;
+    setup(new Rectangle(0, 0, 10, 10));
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('computes the largest multiplier that fits the device limit', () => {
+    // region longest = 10 × 16 = 160 px → 8192 / 160
+    expect(service.maxMultiplier(project)).toBeCloseTo(
+      MAX_EXPORT_DIMENSION / 160
+    );
+  });
+
+  it('reports an error and skips rendering when no renderer is available', async () => {
+    snapshot.available = false;
+    await service.exportImage({
+      project,
+      format: 'png',
+      multiplier: 1,
+      background: true
+    });
+    expect(toast.error).toHaveBeenCalledOnce();
+    expect(snapshot.renderProjectToCanvas).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders at the requested multiplier when within limits and downloads', async () => {
+    await service.exportImage({
+      project,
+      format: 'png',
+      multiplier: 2,
+      background: true
+    });
+    expect(snapshot.renderProjectToCanvas).toHaveBeenCalledWith(project, {
+      multiplier: 2,
+      background: 'grid'
+    });
+    expect(downloads[0]).toBe('MyBoard.png');
+    expect(toast.warn).not.toHaveBeenCalled();
+  });
+
+  it('clamps the multiplier and warns when the output exceeds the limit', async () => {
+    // longest 1000 × 16 = 16000 px → max ≈ 0.512
+    snapshot.computeRegion.mockReturnValue(new Rectangle(0, 0, 1000, 1000));
+    await service.exportImage({
+      project,
+      format: 'png',
+      multiplier: 2,
+      background: true
+    });
+    const used = snapshot.renderProjectToCanvas.mock.calls[0][1].multiplier;
+    expect(used).toBeLessThan(2);
+    expect(used).toBeCloseTo(MAX_EXPORT_DIMENSION / 16000);
+    expect(toast.warn).toHaveBeenCalledOnce();
+  });
+
+  it('maps background off to a transparent render', async () => {
+    await service.exportImage({
+      project,
+      format: 'png',
+      multiplier: 1,
+      background: false
+    });
+    expect(snapshot.renderProjectToCanvas).toHaveBeenCalledWith(project, {
+      multiplier: 1,
+      background: 'transparent'
+    });
+  });
+
+  it('uses the jpg extension and an explicit file name', async () => {
+    await service.exportImage({
+      project,
+      format: 'jpeg',
+      multiplier: 1,
+      background: true,
+      fileName: 'custom'
+    });
+    expect(downloads[0]).toBe('custom.jpg');
+  });
+});

--- a/logigator-editor-v2/src/app/rendering/image-export.service.ts
+++ b/logigator-editor-v2/src/app/rendering/image-export.service.ts
@@ -1,0 +1,152 @@
+import { inject, Injectable } from '@angular/core';
+import { Rectangle } from 'pixi.js';
+import { TranslocoService } from '@jsverse/transloco';
+import { Project } from '../project/project';
+import { ProjectMetadataStore } from '../persistence/project-metadata.store';
+import { ToastService } from '../logging/toast.service';
+import {
+  BoardSnapshotService,
+  SnapshotBackground
+} from './board-snapshot.service';
+import { downloadBlob } from '../utils/download';
+import { environment } from '../../environments/environment';
+
+export type ImageFormat = 'png' | 'jpeg' | 'webp';
+
+export interface ImageExportOptions {
+  project: Project;
+  format: ImageFormat;
+  /** Output pixels per grid unit = `gridSize × multiplier`. */
+  multiplier: number;
+  /** `true` = theme color + dot-grid; `false` = transparent (png/webp) / white (jpeg). */
+  background: boolean;
+  /** 0–1, applied to jpeg/webp. */
+  quality?: number;
+  /** File name without extension; defaults to the project's metadata name. */
+  fileName?: string;
+}
+
+/**
+ * Largest texture side (px) rendered in a single pass. Beyond it the multiplier
+ * is clamped and the user warned, rather than tiling (a documented follow-up).
+ * Conservative across GPUs (WebGPU `maxTextureDimension2D` defaults to 8192) and
+ * browser 2D-canvas limits.
+ */
+export const MAX_EXPORT_DIMENSION = 8192;
+
+const MIME: Record<ImageFormat, string> = {
+  png: 'image/png',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp'
+};
+const EXTENSION: Record<ImageFormat, string> = {
+  png: 'png',
+  jpeg: 'jpg',
+  webp: 'webp'
+};
+const DEFAULT_QUALITY = 0.92;
+const DEFAULT_NAME = 'circuit';
+
+/**
+ * Exports a project's canvas as a downloadable PNG / JPEG / WebP. Orchestration
+ * only — the actual rendering and pixel extraction live in
+ * {@link BoardSnapshotService}.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ImageExportService {
+  private readonly snapshot = inject(BoardSnapshotService);
+  private readonly metadataStore = inject(ProjectMetadataStore);
+  private readonly toast = inject(ToastService);
+  private readonly transloco = inject(TranslocoService);
+
+  /**
+   * Largest multiplier whose output fits {@link MAX_EXPORT_DIMENSION} on both
+   * axes. Used to clamp the export and to drive the dialog's dimension preview.
+   */
+  public maxMultiplier(project: Project): number {
+    return this._maxMultiplier(this.snapshot.computeRegion(project));
+  }
+
+  public async exportImage(options: ImageExportOptions): Promise<void> {
+    if (!this.snapshot.available) {
+      this.toast.error(this.transloco.translate('imageExport.error.unavailable'));
+      return;
+    }
+
+    const region = this.snapshot.computeRegion(options.project);
+    const max = this._maxMultiplier(region);
+    const effective = Math.min(options.multiplier, max);
+    const clamped = effective < options.multiplier;
+
+    let canvas: HTMLCanvasElement;
+    try {
+      canvas = this.snapshot.renderProjectToCanvas(options.project, {
+        multiplier: effective,
+        background: this._backgroundMode(options)
+      });
+    } catch {
+      this.toast.error(this.transloco.translate('imageExport.error.failed'));
+      return;
+    }
+
+    const blob = await this._toBlob(canvas, options);
+    if (!blob) {
+      this.toast.error(this.transloco.translate('imageExport.error.failed'));
+      return;
+    }
+
+    const name =
+      options.fileName ??
+      this.metadataStore.getMetadata(options.project)?.name ??
+      DEFAULT_NAME;
+    downloadBlob(blob, `${name}.${EXTENSION[options.format]}`);
+
+    if (clamped) {
+      const { width, height } = this.snapshot.outputSize(region, effective);
+      this.toast.warn(
+        this.transloco.translate('imageExport.warn.clamped', { width, height })
+      );
+    }
+  }
+
+  private _backgroundMode(options: ImageExportOptions): SnapshotBackground {
+    if (options.background) return 'grid';
+    // JPEG has no alpha; flattening onto white happens in _toBlob, so render
+    // transparent here regardless of format.
+    return 'transparent';
+  }
+
+  private _maxMultiplier(region: Rectangle): number {
+    const longestPx =
+      Math.max(region.width, region.height) * environment.gridSize;
+    return MAX_EXPORT_DIMENSION / longestPx;
+  }
+
+  private _toBlob(
+    canvas: HTMLCanvasElement,
+    options: ImageExportOptions
+  ): Promise<Blob | null> {
+    const source =
+      options.format === 'jpeg' && !options.background
+        ? this._flattenOnWhite(canvas)
+        : canvas;
+    const quality = options.quality ?? DEFAULT_QUALITY;
+    return new Promise((resolve) =>
+      source.toBlob((blob) => resolve(blob), MIME[options.format], quality)
+    );
+  }
+
+  /** JPEG cannot store alpha; composite a transparent render onto white. */
+  private _flattenOnWhite(canvas: HTMLCanvasElement): HTMLCanvasElement {
+    const flat = document.createElement('canvas');
+    flat.width = canvas.width;
+    flat.height = canvas.height;
+    const ctx = flat.getContext('2d')!;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, flat.width, flat.height);
+    ctx.drawImage(canvas, 0, 0);
+    return flat;
+  }
+}

--- a/logigator-editor-v2/src/app/rendering/image-export.service.ts
+++ b/logigator-editor-v2/src/app/rendering/image-export.service.ts
@@ -69,6 +69,23 @@ export class ImageExportService {
     return this._maxMultiplier(this.snapshot.computeRegion(project));
   }
 
+  /**
+   * Output dimensions for a project at a multiplier, with the effective
+   * (possibly clamped) value applied. Drives the dialog's live size preview and
+   * needs no renderer (bounds-only).
+   */
+  public previewSize(
+    project: Project,
+    multiplier: number
+  ): { width: number; height: number; clamped: boolean } {
+    const region = this.snapshot.computeRegion(project);
+    const effective = Math.min(multiplier, this._maxMultiplier(region));
+    return {
+      ...this.snapshot.outputSize(region, effective),
+      clamped: effective < multiplier
+    };
+  }
+
   public async exportImage(options: ImageExportOptions): Promise<void> {
     if (!this.snapshot.available) {
       this.toast.error(this.transloco.translate('imageExport.error.unavailable'));

--- a/logigator-editor-v2/src/app/rendering/renderer-handle.service.ts
+++ b/logigator-editor-v2/src/app/rendering/renderer-handle.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Renderer } from 'pixi.js';
+
+/**
+ * Holds a reference to the live PixiJS renderer owned by {@link BoardComponent}.
+ * Lets non-canvas services (image export, server previews, a future minimap)
+ * render the scene into offscreen textures without reaching into the component.
+ * BoardComponent registers the renderer once the app has initialised and clears
+ * it on teardown.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class RendererHandleService {
+  private _renderer: Renderer | null = null;
+
+  public set(renderer: Renderer | null): void {
+    this._renderer = renderer;
+  }
+
+  public get renderer(): Renderer | null {
+    return this._renderer;
+  }
+
+  public get available(): boolean {
+    return this._renderer !== null;
+  }
+}

--- a/logigator-editor-v2/src/app/theming/theming.service.ts
+++ b/logigator-editor-v2/src/app/theming/theming.service.ts
@@ -38,4 +38,14 @@ export class ThemingService {
     const theme = localStorage.getItem(STORAGE_KEY) as ThemeType | null;
     this.setTheme(theme && THEMES[theme] ? theme : ThemeType.DARK);
   }
+
+  /**
+   * Sets the active theme type without the DOM-class / localStorage side
+   * effects of {@link setTheme}. Intended for briefly switching theme to render
+   * an offscreen snapshot (dual-theme previews); always pair it with a
+   * synchronous restore.
+   */
+  public setActiveThemeType(type: ThemeType): void {
+    this._currentThemeType.set(type);
+  }
 }

--- a/logigator-editor-v2/src/app/ui/board/board.component.ts
+++ b/logigator-editor-v2/src/app/ui/board/board.component.ts
@@ -21,6 +21,7 @@ import { TickerScheduler } from '../../rendering/ticker-scheduler';
 import { EditorSettingsService } from '../../settings/editor-settings.service';
 import { FpsCounterComponent } from './fps-counter/fps-counter.component';
 import { MultiTouchGesture } from '../../rendering/multi-touch-gesture';
+import { RendererHandleService } from '../../rendering/renderer-handle.service';
 
 // Off-screen scene nodes (quad-tree branches, components, wires) are skipped at
 // render time when marked `cullable`. CullerPlugin (priority 10) initialises
@@ -40,6 +41,7 @@ export class BoardComponent implements OnInit, OnDestroy {
   private readonly themingService = inject(ThemingService);
   private readonly assetsService = inject(AssetsService);
   private readonly workModeService = inject(WorkModeService);
+  private readonly rendererHandle = inject(RendererHandleService);
   protected readonly editorSettings = inject(EditorSettingsService);
 
   @ViewChild('canvas', { static: true })
@@ -207,6 +209,10 @@ export class BoardComponent implements OnInit, OnDestroy {
     // earlier would invert that and leak a stray single-pointer session.
     this._wireTouchGestures();
 
+    // Expose the renderer for offscreen snapshots (image export, server
+    // previews). Cleared in ngOnDestroy before the app is destroyed.
+    this.rendererHandle.set(this.app.renderer);
+
     this.appInitialized = true;
     this.loaded.set(true);
   }
@@ -216,6 +222,7 @@ export class BoardComponent implements OnInit, OnDestroy {
     this._gestureListeners.abort();
     this._resizeObserver?.disconnect();
     this._renderScheduler?.destroy();
+    this.rendererHandle.set(null);
     if (this.appInitialized) {
       this.app.destroy();
     }

--- a/logigator-editor-v2/src/app/ui/debug-menu.service.ts
+++ b/logigator-editor-v2/src/app/ui/debug-menu.service.ts
@@ -1,0 +1,115 @@
+/* eslint-disable no-console -- this menu's purpose is raw console output */
+import { inject, Injectable } from '@angular/core';
+import { MenuItem } from 'primeng/api';
+import { RendererType, type Renderer, type WebGLRenderer } from 'pixi.js';
+import { environment } from '../../environments/environment';
+import { ProjectService } from '../project/project.service';
+import { BoardCompilerService } from '../simulation/compiler/board-compiler.service';
+import { RendererHandleService } from '../rendering/renderer-handle.service';
+import { PersistenceService } from '../persistence/persistence.service';
+import { ToastService } from '../logging/toast.service';
+import { pickTextFile } from '../utils/file-picker';
+
+/**
+ * Builds the title-bar "Debug" menu and owns its commands. Gated by
+ * `environment.debug.menu` — {@link buildMenuItem} returns `null` when disabled,
+ * so the menu is absent in production. Output goes to the console (and a toast
+ * where a console object is not enough); these are developer tools and are
+ * intentionally untranslated.
+ */
+@Injectable({ providedIn: 'root' })
+export class DebugMenuService {
+  private readonly projectService = inject(ProjectService);
+  private readonly boardCompiler = inject(BoardCompilerService);
+  private readonly rendererHandle = inject(RendererHandleService);
+  private readonly persistence = inject(PersistenceService);
+  private readonly toast = inject(ToastService);
+
+  public readonly enabled = environment.debug.menu;
+
+  /** The top-level "Debug" menubar item, or `null` when the menu is disabled. */
+  public buildMenuItem(): MenuItem | null {
+    if (!this.enabled) return null;
+    return {
+      label: 'Debug',
+      items: [
+        {
+          label: 'Print compiled board',
+          command: () => this.printCompiledBoard()
+        },
+        {
+          label: 'Print renderer mode',
+          command: () => this.printRendererMode()
+        },
+        { separator: true },
+        { label: 'Generate dump', command: () => this.generateDump() },
+        { label: 'Import dump', command: () => this.importDump() }
+      ]
+    };
+  }
+
+  private printCompiledBoard(): void {
+    const project = this.projectService.activeProject();
+    if (!project) {
+      this.toast.warn('No active project to compile.');
+      return;
+    }
+    try {
+      const compiled = this.boardCompiler.compile(project);
+      console.log('[debug] compiled board', compiled);
+    } catch (err) {
+      console.error('[debug] failed to compile board', err);
+      this.toast.error('Failed to compile board — see console.');
+    }
+  }
+
+  private printRendererMode(): void {
+    const renderer = this.rendererHandle.renderer;
+    if (!renderer) {
+      this.toast.warn('Renderer is not ready yet.');
+      return;
+    }
+    const mode = this.rendererMode(renderer);
+    console.log('[debug] renderer mode:', mode, renderer);
+    this.toast.info(`Renderer: ${mode}`);
+  }
+
+  private generateDump(): void {
+    const project = this.projectService.activeProject();
+    if (!project) {
+      this.toast.warn('No active project to dump.');
+      return;
+    }
+    this.persistence.exportProjectDumpToFile(project);
+  }
+
+  private importDump(): void {
+    void pickTextFile('.json,application/json').then((content) => {
+      if (content === null) return;
+      this.persistence
+        .importProjectDump(content)
+        .then(() => this.toast.success('Project dump imported.'))
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error('[debug] failed to import dump', err);
+          this.toast.error(`Failed to import dump: ${message}`);
+        });
+    });
+  }
+
+  /** Resolves which backend the live renderer is running on. */
+  private rendererMode(renderer: Renderer): string {
+    switch (renderer.type) {
+      case RendererType.WEBGPU:
+        return 'WebGPU';
+      case RendererType.WEBGL: {
+        const version = (renderer as WebGLRenderer).context?.webGLVersion;
+        return version ? `WebGL ${version}` : 'WebGL';
+      }
+      case RendererType.CANVAS:
+        return 'Canvas';
+      default:
+        return renderer.name || `Unknown (type ${renderer.type})`;
+    }
+  }
+}

--- a/logigator-editor-v2/src/app/ui/debug-menu.service.ts
+++ b/logigator-editor-v2/src/app/ui/debug-menu.service.ts
@@ -12,7 +12,7 @@ import { pickTextFile } from '../utils/file-picker';
 
 /**
  * Builds the title-bar "Debug" menu and owns its commands. Gated by
- * `environment.debug.menu` — {@link buildMenuItem} returns `null` when disabled,
+ * `environment.debug.debugMenu` — {@link buildMenuItem} returns `null` when disabled,
  * so the menu is absent in production. Output goes to the console (and a toast
  * where a console object is not enough); these are developer tools and are
  * intentionally untranslated.
@@ -25,7 +25,7 @@ export class DebugMenuService {
   private readonly persistence = inject(PersistenceService);
   private readonly toast = inject(ToastService);
 
-  public readonly enabled = environment.debug.menu;
+  public readonly enabled = environment.debug.debugMenu;
 
   /** The top-level "Debug" menubar item, or `null` when the menu is disabled. */
   public buildMenuItem(): MenuItem | null {

--- a/logigator-editor-v2/src/app/ui/editor-menu.service.ts
+++ b/logigator-editor-v2/src/app/ui/editor-menu.service.ts
@@ -14,6 +14,7 @@ import { SaveCoordinatorService } from './save-coordinator.service';
 import { OpenProjectDialogComponent } from './open-project-dialog/open-project-dialog.component';
 import { NewComponentDialogComponent } from './new-component-dialog/new-component-dialog.component';
 import { ShortcutManagerComponent } from '../shortcuts/shortcut-manager/shortcut-manager.component';
+import { ExportImageDialogComponent } from './export-image-dialog/export-image-dialog.component';
 
 /**
  * Builds the File/Edit/View/Help menu model and owns the commands behind it.
@@ -89,7 +90,8 @@ export class EditorMenuService {
           {
             label: this.translocoService.translate(
               'titleBar.menuBar.file.items.generateImage.label'
-            )
+            ),
+            command: () => this.generateImage()
           }
         ]
       },
@@ -243,6 +245,15 @@ export class EditorMenuService {
     if (project) {
       this.persistenceService.exportProjectToFile(project);
     }
+  }
+
+  private generateImage(): void {
+    this.dialogService.open(ExportImageDialogComponent, {
+      header: this.translocoService.translate('imageExport.title'),
+      width: '28rem',
+      modal: true,
+      closable: true
+    });
   }
 
   private newComponent(): void {

--- a/logigator-editor-v2/src/app/ui/editor-menu.service.ts
+++ b/logigator-editor-v2/src/app/ui/editor-menu.service.ts
@@ -15,6 +15,7 @@ import { OpenProjectDialogComponent } from './open-project-dialog/open-project-d
 import { NewComponentDialogComponent } from './new-component-dialog/new-component-dialog.component';
 import { ShortcutManagerComponent } from '../shortcuts/shortcut-manager/shortcut-manager.component';
 import { ExportImageDialogComponent } from './export-image-dialog/export-image-dialog.component';
+import { DebugMenuService } from './debug-menu.service';
 
 /**
  * Builds the File/Edit/View/Help menu model and owns the commands behind it.
@@ -32,6 +33,7 @@ export class EditorMenuService {
   private readonly clipboardService = inject(ClipboardService);
   private readonly shortcutService = inject(ShortcutService);
   private readonly saveCoordinator = inject(SaveCoordinatorService);
+  private readonly debugMenuService = inject(DebugMenuService);
 
   /** Rebuilt whenever the active language changes so labels stay translated. */
   public readonly items: Signal<MenuItem[]> = toSignal(
@@ -40,7 +42,7 @@ export class EditorMenuService {
   );
 
   private generateMenuItems(): MenuItem[] {
-    return [
+    const items: MenuItem[] = [
       {
         label: this.translocoService.translate('titleBar.menuBar.file.label'),
         items: [
@@ -193,6 +195,11 @@ export class EditorMenuService {
         label: 'Help'
       }
     ];
+
+    const debugMenu = this.debugMenuService.buildMenuItem();
+    if (debugMenu) items.push(debugMenu);
+
+    return items;
   }
 
   private openShortcutManager(): void {

--- a/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.html
+++ b/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.html
@@ -1,0 +1,84 @@
+<form *transloco="let t" class="flex flex-col gap-4" (ngSubmit)="export()">
+  @if (projectOptions().length > 1) {
+    <div class="flex flex-col gap-1">
+      <label for="export-project">{{ t('imageExport.project') }}</label>
+      <p-select
+        inputId="export-project"
+        [options]="projectOptions()"
+        optionLabel="label"
+        optionValue="value"
+        [ngModel]="project()"
+        (ngModelChange)="project.set($event)"
+        [ngModelOptions]="{ standalone: true }"
+      />
+    </div>
+  }
+  <div class="flex flex-col gap-1">
+    <span>{{ t('imageExport.format') }}</span>
+    <p-selectButton
+      [options]="formatOptions"
+      optionLabel="label"
+      optionValue="value"
+      [allowEmpty]="false"
+      [ngModel]="format()"
+      (ngModelChange)="format.set($event)"
+      [ngModelOptions]="{ standalone: true }"
+    />
+  </div>
+  <div class="flex flex-col gap-1">
+    <span>{{ t('imageExport.resolution') }}</span>
+    <p-selectButton
+      [options]="resolutionOptions"
+      optionLabel="label"
+      optionValue="value"
+      [allowEmpty]="false"
+      [ngModel]="multiplier()"
+      (ngModelChange)="multiplier.set($event)"
+      [ngModelOptions]="{ standalone: true }"
+    />
+    @if (dimensions(); as d) {
+      <span class="text-sm text-muted">
+        {{ t('imageExport.dimensions', { width: d.width, height: d.height }) }}
+      </span>
+    }
+  </div>
+  <div class="flex items-center gap-2">
+    <p-toggleswitch
+      inputId="export-background"
+      [ngModel]="background()"
+      (ngModelChange)="background.set($event)"
+      [ngModelOptions]="{ standalone: true }"
+    />
+    <label for="export-background">{{ t('imageExport.background') }}</label>
+    <span class="text-sm text-muted">{{ t('imageExport.backgroundHint') }}</span>
+  </div>
+  @if (showQuality()) {
+    <div class="flex flex-col gap-1">
+      <label for="export-quality"
+        >{{ t('imageExport.quality') }} — {{ quality() }}%</label
+      >
+      <p-slider
+        [min]="10"
+        [max]="100"
+        [ngModel]="quality()"
+        (ngModelChange)="quality.set($event)"
+        [ngModelOptions]="{ standalone: true }"
+      />
+    </div>
+  }
+  <div class="flex justify-end gap-2">
+    <p-button
+      type="button"
+      severity="secondary"
+      [outlined]="true"
+      [label]="t('imageExport.cancel')"
+      (onClick)="cancel()"
+    />
+    <p-button
+      type="submit"
+      [label]="t('imageExport.export')"
+      [disabled]="!canExport"
+      [loading]="exporting()"
+    />
+  </div>
+</form>

--- a/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.html
+++ b/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.html
@@ -7,8 +7,8 @@
         [options]="projectOptions()"
         optionLabel="label"
         optionValue="value"
-        [ngModel]="project()"
-        (ngModelChange)="project.set($event)"
+        [ngModel]="selectedIndex()"
+        (ngModelChange)="selectedIndex.set($event)"
         [ngModelOptions]="{ standalone: true }"
       />
     </div>
@@ -39,6 +39,9 @@
     @if (dimensions(); as d) {
       <span class="text-sm text-muted">
         {{ t('imageExport.dimensions', { width: d.width, height: d.height }) }}
+        @if (d.clamped) {
+          {{ t('imageExport.clampedHint') }}
+        }
       </span>
     }
   </div>

--- a/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.ts
+++ b/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.ts
@@ -60,21 +60,25 @@ export class ExportImageDialogComponent {
     { label: '4×', value: 4 }
   ];
 
-  /** Main project plus any open component editors, labelled by their name. */
-  protected readonly projectOptions = computed(() => {
+  /** Main project plus any open component editors. */
+  private readonly _projects = computed<Project[]>(() => {
     const main = this.projectService.mainProject();
-    const projects = [
-      ...(main ? [main] : []),
-      ...this.projectService.openComponents()
-    ];
-    return projects.map((project) => ({
-      label: this._projectName(project),
-      value: project
-    }));
+    return [...(main ? [main] : []), ...this.projectService.openComponents()];
   });
 
-  protected readonly project = signal<Project | null>(
-    this.projectService.activeProject() ?? this.projectService.mainProject()
+  // Options carry the array index (a primitive) rather than the Project itself:
+  // a Project is a deep, circular PixiJS Container, and p-select would run
+  // deepEquals over it for option matching.
+  protected readonly projectOptions = computed(() =>
+    this._projects().map((project, index) => ({
+      label: this._projectName(project),
+      value: index
+    }))
+  );
+
+  protected readonly selectedIndex = signal(this._initialIndex());
+  protected readonly project = computed<Project | null>(
+    () => this._projects()[this.selectedIndex()] ?? null
   );
   protected readonly format = signal<ImageFormat>('png');
   protected readonly multiplier = signal(2);
@@ -114,6 +118,12 @@ export class ExportImageDialogComponent {
 
   protected cancel(): void {
     this.ref.close();
+  }
+
+  private _initialIndex(): number {
+    const active = this.projectService.activeProject();
+    const index = active ? this._projects().indexOf(active) : -1;
+    return index >= 0 ? index : 0;
   }
 
   private _projectName(project: Project): string {

--- a/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.ts
+++ b/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.ts
@@ -1,0 +1,122 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { SelectButtonModule } from 'primeng/selectbutton';
+import { SelectModule } from 'primeng/select';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
+import { SliderModule } from 'primeng/slider';
+import { Button } from 'primeng/button';
+import { TranslocoDirective } from '@jsverse/transloco';
+import { ProjectService } from '../../project/project.service';
+import { ProjectMetadataStore } from '../../persistence/project-metadata.store';
+import {
+  ImageExportService,
+  ImageFormat
+} from '../../rendering/image-export.service';
+import { Project } from '../../project/project';
+
+/** Slider default; converted to a 0–1 quality on export. */
+const DEFAULT_QUALITY_PERCENT = 92;
+
+/**
+ * Collects image-export settings (project, format, resolution, background,
+ * JPEG/WebP quality) and delegates the work to {@link ImageExportService}. The
+ * dialog closes once the export resolves; success/failure surfaces as a toast.
+ */
+@Component({
+  selector: 'app-export-image-dialog',
+  imports: [
+    FormsModule,
+    SelectButtonModule,
+    SelectModule,
+    ToggleSwitchModule,
+    SliderModule,
+    Button,
+    TranslocoDirective
+  ],
+  templateUrl: './export-image-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ExportImageDialogComponent {
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly projectService = inject(ProjectService);
+  private readonly metadataStore = inject(ProjectMetadataStore);
+  private readonly imageExport = inject(ImageExportService);
+
+  protected readonly formatOptions = [
+    { label: 'PNG', value: 'png' as const },
+    { label: 'JPEG', value: 'jpeg' as const },
+    { label: 'WebP', value: 'webp' as const }
+  ];
+  protected readonly resolutionOptions = [
+    { label: '1×', value: 1 },
+    { label: '2×', value: 2 },
+    { label: '4×', value: 4 }
+  ];
+
+  /** Main project plus any open component editors, labelled by their name. */
+  protected readonly projectOptions = computed(() => {
+    const main = this.projectService.mainProject();
+    const projects = [
+      ...(main ? [main] : []),
+      ...this.projectService.openComponents()
+    ];
+    return projects.map((project) => ({
+      label: this._projectName(project),
+      value: project
+    }));
+  });
+
+  protected readonly project = signal<Project | null>(
+    this.projectService.activeProject() ?? this.projectService.mainProject()
+  );
+  protected readonly format = signal<ImageFormat>('png');
+  protected readonly multiplier = signal(2);
+  protected readonly background = signal(true);
+  protected readonly quality = signal(DEFAULT_QUALITY_PERCENT);
+  protected readonly exporting = signal(false);
+
+  /** PNG is lossless, so the quality control only applies to JPEG/WebP. */
+  protected readonly showQuality = computed(() => this.format() !== 'png');
+
+  protected readonly dimensions = computed(() => {
+    const project = this.project();
+    return project ? this.imageExport.previewSize(project, this.multiplier()) : null;
+  });
+
+  protected get canExport(): boolean {
+    return !!this.project() && !this.exporting();
+  }
+
+  protected async export(): Promise<void> {
+    const project = this.project();
+    if (!project || this.exporting()) return;
+    this.exporting.set(true);
+    try {
+      await this.imageExport.exportImage({
+        project,
+        format: this.format(),
+        multiplier: this.multiplier(),
+        background: this.background(),
+        quality: this.quality() / 100
+      });
+    } finally {
+      this.exporting.set(false);
+      this.ref.close();
+    }
+  }
+
+  protected cancel(): void {
+    this.ref.close();
+  }
+
+  private _projectName(project: Project): string {
+    return this.metadataStore.getMetadata(project)?.name ?? 'Untitled';
+  }
+}

--- a/logigator-editor-v2/src/app/utils/download.ts
+++ b/logigator-editor-v2/src/app/utils/download.ts
@@ -1,0 +1,12 @@
+/**
+ * Triggers a browser download of a Blob via a transient object URL. Shared by
+ * file export (native circuit format) and image export.
+ */
+export function downloadBlob(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/logigator-editor-v2/src/app/utils/file-picker.ts
+++ b/logigator-editor-v2/src/app/utils/file-picker.ts
@@ -1,0 +1,25 @@
+/**
+ * Opens the browser's file picker and resolves with the chosen file's text, or
+ * `null` if the read fails. Uses a transient `<input type="file">` so no markup
+ * is needed at the call site. Note: a cancelled picker never fires `change`, so
+ * the promise simply never resolves — fine for the debug-menu use case.
+ */
+export function pickTextFile(accept = ''): Promise<string | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    if (accept) input.accept = accept;
+    input.addEventListener('change', () => {
+      const file = input.files?.[0];
+      if (!file) {
+        resolve(null);
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => resolve(null);
+      reader.readAsText(file);
+    });
+    input.click();
+  });
+}

--- a/logigator-editor-v2/src/environments/environment.development.ts
+++ b/logigator-editor-v2/src/environments/environment.development.ts
@@ -9,6 +9,6 @@ export const environment: Environment = {
     showOrigins: false,
     showConnectionPoints: false,
     showQuadTrees: false,
-    menu: true
+    debugMenu: true
   }
 };

--- a/logigator-editor-v2/src/environments/environment.development.ts
+++ b/logigator-editor-v2/src/environments/environment.development.ts
@@ -8,6 +8,7 @@ export const environment: Environment = {
     showHitboxes: false,
     showOrigins: false,
     showConnectionPoints: false,
-    showQuadTrees: false
+    showQuadTrees: false,
+    menu: true
   }
 };

--- a/logigator-editor-v2/src/environments/environment.model.ts
+++ b/logigator-editor-v2/src/environments/environment.model.ts
@@ -9,6 +9,6 @@ export interface Environment {
     showQuadTrees: boolean;
     /** Shows the title-bar "Debug" menu (compiled-board/renderer dumps, Project
      * Dump export/import). Off in production. */
-    menu: boolean;
+    debugMenu: boolean;
   };
 }

--- a/logigator-editor-v2/src/environments/environment.model.ts
+++ b/logigator-editor-v2/src/environments/environment.model.ts
@@ -7,5 +7,8 @@ export interface Environment {
     showOrigins: boolean;
     showConnectionPoints: boolean;
     showQuadTrees: boolean;
+    /** Shows the title-bar "Debug" menu (compiled-board/renderer dumps, Project
+     * Dump export/import). Off in production. */
+    menu: boolean;
   };
 }

--- a/logigator-editor-v2/src/environments/environment.ts
+++ b/logigator-editor-v2/src/environments/environment.ts
@@ -8,6 +8,7 @@ export const environment: Environment = {
     showHitboxes: false,
     showOrigins: false,
     showConnectionPoints: false,
-    showQuadTrees: false
+    showQuadTrees: false,
+    menu: false
   }
 };

--- a/logigator-editor-v2/src/environments/environment.ts
+++ b/logigator-editor-v2/src/environments/environment.ts
@@ -9,6 +9,6 @@ export const environment: Environment = {
     showOrigins: false,
     showConnectionPoints: false,
     showQuadTrees: false,
-    menu: false
+    debugMenu: false
   }
 };

--- a/logigator-editor-v2/src/i18n/en.ts
+++ b/logigator-editor-v2/src/i18n/en.ts
@@ -287,6 +287,26 @@ const en = {
     info: 'Info',
     debug: 'Debug'
   },
+  imageExport: {
+    title: 'Export image',
+    project: 'Project',
+    format: 'Format',
+    resolution: 'Resolution',
+    background: 'Background',
+    backgroundHint: 'Theme color and grid',
+    quality: 'Quality',
+    dimensions: '{{width}} × {{height}} px',
+    export: 'Export',
+    cancel: 'Cancel',
+    error: {
+      unavailable: 'The editor is not ready yet. Try again in a moment.',
+      failed: 'Image export failed.'
+    },
+    warn: {
+      clamped:
+        'Resolution reduced to fit device limits; exported at {{width}} × {{height}} px.'
+    }
+  },
   shortcuts: {
     title: 'Keyboard Shortcuts',
     actions: {

--- a/logigator-editor-v2/src/i18n/en.ts
+++ b/logigator-editor-v2/src/i18n/en.ts
@@ -296,6 +296,7 @@ const en = {
     backgroundHint: 'Theme color and grid',
     quality: 'Quality',
     dimensions: '{{width}} × {{height}} px',
+    clampedHint: '(reduced to fit device limits)',
     export: 'Export',
     cancel: 'Cancel',
     error: {


### PR DESCRIPTION
This pull request introduces a robust serialization and deserialization system for the undo/redo action history in the Logigator Editor, enabling full session state to be exported and restored via a debug "Project Dump" feature. The changes add a JSON-safe representation for all actions, implement serialization logic for each action type, and provide mechanisms to restore the action history and pointer accurately.

Key changes include:

**Action Serialization and Deserialization:**

* Added a `SerializedAction` type and related interfaces in `serialized-action.model.ts` to represent all possible actions in a JSON-safe, discriminated union format.
* Implemented `serialize()` methods for all action classes (`AddComponentsAction`, `RemoveComponentsAction`, `AddWiresAction`, `RemoveWiresAction`, `MoveComponentsAction`, `MoveWiresAction`, `ChangeOptionAction`, `TogglePortNegationAction`, and `ActionContainer`), enabling each to output its state in the new serializable format. [[1]](diffhunk://#diff-2227eabbe8c519d3eaa6a525c4f7cb5cbe33191928d70a4d36b67ebaae6c36e7L15-R30) [[2]](diffhunk://#diff-126aed6046539b3f6fc5b2d5da805f51f26c577210b2ffb5d84bc234df17b2d7R29-R32) [[3]](diffhunk://#diff-fbda13cd31a568a3588c63691a67c6ab2e70608fae7466e7bae910197afab15aR22-R25) [[4]](diffhunk://#diff-7c173dd2b98d789f5dfb337e1800dd64621a93e8f85a2929e430155145cab885R22-R25) [[5]](diffhunk://#diff-37deacedc16a75f758ca03ee2ac6aa421a7cdb165ba32b11ecee260f350f71dbR18-R24) [[6]](diffhunk://#diff-ba7e72b236d5ca78f8708e75722f84b8a9ce4450c0946ba4822c1944c434e780R18-R21) [[7]](diffhunk://#diff-8f3f4596fd4c785c7653621a63119eac3c91f267fad713a40358471e5f50759fR15-R24) [[8]](diffhunk://#diff-b5c77069743514cba513bce90e7c1e5c8086216ac8ed93cd11dd6439e4f97f87R22-R31) [[9]](diffhunk://#diff-d368ae3a38318cf7fd4d45e383d1f6186cc89de6b127962e44e54b35efb76651R13-R19)
* Added `serializeMoveEntries` and `deserializeMoveEntries` helper functions to flatten and restore move entry data for serialization.
* Created a `deserializeAction` function in `action-codec.ts` to reconstruct actions from their serialized form.

**Action Manager and Debug Project Dump Integration:**

* Exposed `history` and `pointer` as read-only properties on `ActionManager` for use in debug dumps, and added a `restore()` method to load a given history and pointer.
* Defined the `ProjectDump` interface and versioning in `project-dump.types.ts`, specifying how the project state and action history are bundled for debug import/export.

**Supporting Changes:**

* Updated imports and type usages throughout the action classes to support the new serialization interfaces. [[1]](diffhunk://#diff-d368ae3a38318cf7fd4d45e383d1f6186cc89de6b127962e44e54b35efb76651R3) [[2]](diffhunk://#diff-07442efee961e07d54a8f9c88b816498187a7a40e60c2270eb0bff3461fce547R2-R13) [[3]](diffhunk://#diff-2227eabbe8c519d3eaa6a525c4f7cb5cbe33191928d70a4d36b67ebaae6c36e7R3) [[4]](diffhunk://#diff-fbda13cd31a568a3588c63691a67c6ab2e70608fae7466e7bae910197afab15aR5) [[5]](diffhunk://#diff-8f3f4596fd4c785c7653621a63119eac3c91f267fad713a40358471e5f50759fR3) [[6]](diffhunk://#diff-126aed6046539b3f6fc5b2d5da805f51f26c577210b2ffb5d84bc234df17b2d7R3) [[7]](diffhunk://#diff-7c173dd2b98d789f5dfb337e1800dd64621a93e8f85a2929e430155145cab885R5) [[8]](diffhunk://#diff-37deacedc16a75f758ca03ee2ac6aa421a7cdb165ba32b11ecee260f350f71dbL3-R4) [[9]](diffhunk://#diff-ba7e72b236d5ca78f8708e75722f84b8a9ce4450c0946ba4822c1944c434e780L3-R4) [[10]](diffhunk://#diff-b5c77069743514cba513bce90e7c1e5c8086216ac8ed93cd11dd6439e4f97f87R4) [[11]](diffhunk://#diff-321da2f680ff4fe9c4efa57d35452ba29e8f35a4f2393d4c973773545e4ae049R23-R24)

These enhancements ensure that the full undo/redo stack can be exported, inspected, and restored, greatly improving debugging and session reproducibility.

**References:**  
[[1]](diffhunk://#diff-757a29f61af94940d383fe526cd5d41bddbbb7d366d6231f19795bec1cb240baR1-R43) [[2]](diffhunk://#diff-2227eabbe8c519d3eaa6a525c4f7cb5cbe33191928d70a4d36b67ebaae6c36e7L15-R30) [[3]](diffhunk://#diff-126aed6046539b3f6fc5b2d5da805f51f26c577210b2ffb5d84bc234df17b2d7R29-R32) [[4]](diffhunk://#diff-fbda13cd31a568a3588c63691a67c6ab2e70608fae7466e7bae910197afab15aR22-R25) [[5]](diffhunk://#diff-7c173dd2b98d789f5dfb337e1800dd64621a93e8f85a2929e430155145cab885R22-R25) [[6]](diffhunk://#diff-37deacedc16a75f758ca03ee2ac6aa421a7cdb165ba32b11ecee260f350f71dbR18-R24) [[7]](diffhunk://#diff-ba7e72b236d5ca78f8708e75722f84b8a9ce4450c0946ba4822c1944c434e780R18-R21) [[8]](diffhunk://#diff-8f3f4596fd4c785c7653621a63119eac3c91f267fad713a40358471e5f50759fR15-R24) [[9]](diffhunk://#diff-b5c77069743514cba513bce90e7c1e5c8086216ac8ed93cd11dd6439e4f97f87R22-R31) [[10]](diffhunk://#diff-d368ae3a38318cf7fd4d45e383d1f6186cc89de6b127962e44e54b35efb76651R13-R19) [[11]](diffhunk://#diff-bdfe9b26ecde212ed9761d3011c82347695ee72808a85cc2e84f63c8453474a8R2-R30) [[12]](diffhunk://#diff-5d8adec263c592e21666531d4ceffd83dd3135c33115d4576c339c91eb27a33fR1-R58) [[13]](diffhunk://#diff-9d3c678d33689b41aa2b4ac2fcd14983989f878ddd38695b442654f1cf5dc754R63-R85) [[14]](diffhunk://#diff-7d9f6fab529b0fc33bdb3f13cb1c98ca5496c9b98253ba7d7cc664954c68688fR1-R28) [[15]](diffhunk://#diff-d368ae3a38318cf7fd4d45e383d1f6186cc89de6b127962e44e54b35efb76651R3) [[16]](diffhunk://#diff-07442efee961e07d54a8f9c88b816498187a7a40e60c2270eb0bff3461fce547R2-R13) [[17]](diffhunk://#diff-2227eabbe8c519d3eaa6a525c4f7cb5cbe33191928d70a4d36b67ebaae6c36e7R3) [[18]](diffhunk://#diff-fbda13cd31a568a3588c63691a67c6ab2e70608fae7466e7bae910197afab15aR5) [[19]](diffhunk://#diff-8f3f4596fd4c785c7653621a63119eac3c91f267fad713a40358471e5f50759fR3) [[20]](diffhunk://#diff-126aed6046539b3f6fc5b2d5da805f51f26c577210b2ffb5d84bc234df17b2d7R3) [[21]](diffhunk://#diff-7c173dd2b98d789f5dfb337e1800dd64621a93e8f85a2929e430155145cab885R5) [[22]](diffhunk://#diff-37deacedc16a75f758ca03ee2ac6aa421a7cdb165ba32b11ecee260f350f71dbL3-R4) [[23]](diffhunk://#diff-ba7e72b236d5ca78f8708e75722f84b8a9ce4450c0946ba4822c1944c434e780L3-R4) [[24]](diffhunk://#diff-b5c77069743514cba513bce90e7c1e5c8086216ac8ed93cd11dd6439e4f97f87R4) [[25]](diffhunk://#diff-321da2f680ff4fe9c4efa57d35452ba29e8f35a4f2393d4c973773545e4ae049R23-R24)