### PR TITLE
Feat/upsert local components

### DIFF
--- a/logigator-editor-v2/src/app/app.component.spec.ts
+++ b/logigator-editor-v2/src/app/app.component.spec.ts
@@ -47,6 +47,8 @@ describe('AppComponent', () => {
           provide: PersistenceService,
           useValue: {
             preloadBrowserMasters: vi.fn().mockResolvedValue(undefined),
+            preloadComponentIdAliases: vi.fn().mockResolvedValue(undefined),
+            preloadServerMasters: vi.fn().mockResolvedValue(undefined),
             createAndSetEmptyProject: vi.fn(),
             registerOpenProject: vi.fn()
           }

--- a/logigator-editor-v2/src/app/app.component.ts
+++ b/logigator-editor-v2/src/app/app.component.ts
@@ -138,9 +138,17 @@ export class AppComponent {
       }
     });
 
-    void this.persistenceService.preloadComponentIdAliases();
-    void this.persistenceService.preloadBrowserMasters();
-    void this.persistenceService.preloadServerMasters();
+    // Load promotion aliases first: the browser preload skips records whose id
+    // was promoted to the cloud, and snapshots embedded before a promotion resolve
+    // through the alias — both need the alias map in place. Masters then load
+    // concurrently.
+    void (async () => {
+      await this.persistenceService.preloadComponentIdAliases();
+      await Promise.all([
+        this.persistenceService.preloadBrowserMasters(),
+        this.persistenceService.preloadServerMasters()
+      ]);
+    })();
 
     if (!this.routerService.matches(this.location.path())) {
       this.persistenceService.createAndSetEmptyProject();

--- a/logigator-editor-v2/src/app/app.component.ts
+++ b/logigator-editor-v2/src/app/app.component.ts
@@ -138,7 +138,9 @@ export class AppComponent {
       }
     });
 
+    void this.persistenceService.preloadComponentIdAliases();
     void this.persistenceService.preloadBrowserMasters();
+    void this.persistenceService.preloadServerMasters();
 
     if (!this.routerService.matches(this.location.path())) {
       this.persistenceService.createAndSetEmptyProject();

--- a/logigator-editor-v2/src/app/components/component-config.model.ts
+++ b/logigator-editor-v2/src/app/components/component-config.model.ts
@@ -60,6 +60,12 @@ export interface ComponentConfigView<
   symbol: string;
   name: LocalizableText;
   description: LocalizableText;
+  /**
+   * Which library a custom component lives in — `'server'` (cloud) or
+   * `'browser'` (local). A live view of its definition's source, so it tracks an
+   * upload-to-cloud promotion. Absent on built-ins (which have no storage location).
+   */
+  source?: 'server' | 'browser';
   options: TOptions;
   /**
    * Valueless inspector actions (buttons) rendered after the options form, each

--- a/logigator-editor-v2/src/app/components/custom/actions/update-instance-action.component.ts
+++ b/logigator-editor-v2/src/app/components/custom/actions/update-instance-action.component.ts
@@ -63,8 +63,12 @@ export class UpdateInstanceActionComponent {
       def?.id !== undefined
         ? this.registry.masterTypeIdForId(def.id)
         : undefined;
-    if (masterTypeId !== undefined) {
-      await this.customComponentService.ensureMasterCircuit(masterTypeId);
+    if (
+      masterTypeId !== undefined &&
+      !(await this.customComponentService.ensureMasterCircuit(masterTypeId))
+    ) {
+      // Cloud fetch failed (the service toasted) — leave the instance as-is.
+      return;
     }
     const action = this.customComponentService.buildInstanceUpdate(component);
     if (action) project.actionManager.push(action);

--- a/logigator-editor-v2/src/app/components/custom/actions/update-instance-action.component.ts
+++ b/logigator-editor-v2/src/app/components/custom/actions/update-instance-action.component.ts
@@ -54,9 +54,18 @@ export class UpdateInstanceActionComponent {
     );
   });
 
-  protected update(): void {
+  protected async update(): Promise<void> {
     const { component, project } = this.context();
     if (!(component instanceof CustomComponent)) return;
+    // The master may be a summary-only cloud preload; load its circuit first.
+    const def = this.registry.getDefinition(component.config.type);
+    const masterTypeId =
+      def?.id !== undefined
+        ? this.registry.masterTypeIdForId(def.id)
+        : undefined;
+    if (masterTypeId !== undefined) {
+      await this.customComponentService.ensureMasterCircuit(masterTypeId);
+    }
     const action = this.customComponentService.buildInstanceUpdate(component);
     if (action) project.actionManager.push(action);
   }

--- a/logigator-editor-v2/src/app/components/custom/actions/upload-component-action.component.ts
+++ b/logigator-editor-v2/src/app/components/custom/actions/upload-component-action.component.ts
@@ -7,32 +7,42 @@ import {
 } from '@angular/core';
 import { Button } from 'primeng/button';
 import { Tooltip } from 'primeng/tooltip';
+import { DialogService } from 'primeng/dynamicdialog';
+import { TranslocoDirective, TranslocoService } from '@jsverse/transloco';
 import { ComponentActionContext } from '../../component-action';
 import { CustomComponentRegistry } from '../custom-component-registry.service';
 import { CustomComponentService } from '../../../custom-component/custom-component.service';
 import { UserService } from '../../../user/user.service';
+import {
+  UploadComponentDialogComponent,
+  UploadComponentDialogData,
+  UploadComponentDialogResult
+} from '../../../ui/upload-component-dialog/upload-component-dialog.component';
 
 /**
  * Renderer for {@link UploadComponentAction}: a button shown only when the
- * selected instance resolves to a **local** master, which uploads (moves) that
- * master to the user's cloud library. Disabled with a hint when signed out.
- * Self-contained — owns its own visibility, auth gating and dispatch.
+ * selected instance resolves to a **local** master, which opens the upload-to-cloud
+ * dialog for that master (visibility + optional dependency upload). Disabled with a
+ * hint when signed out. Self-contained — owns its own visibility, auth gating and
+ * dispatch.
  */
 @Component({
   selector: 'app-upload-component-action',
-  imports: [Button, Tooltip],
-  template: `@if (visible()) {
-    <p-button
-      size="small"
-      icon="ph ph-cloud-arrow-up"
-      label="Upload to cloud"
-      class="float-right"
-      [disabled]="!authenticated()"
-      [pTooltip]="authenticated() ? '' : 'Sign in to upload to the cloud'"
-      tooltipPosition="top"
-      (onClick)="upload()"
-    />
-  }`,
+  imports: [Button, Tooltip, TranslocoDirective],
+  template: `<ng-container *transloco="let t">
+    @if (visible()) {
+      <p-button
+        size="small"
+        icon="ph ph-cloud-arrow-up"
+        [label]="t('uploadComponent.button')"
+        class="float-right"
+        [disabled]="!authenticated()"
+        [pTooltip]="authenticated() ? '' : t('uploadComponent.signInTooltip')"
+        tooltipPosition="top"
+        (onClick)="upload()"
+      />
+    }
+  </ng-container>`,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UploadComponentActionComponent {
@@ -41,6 +51,8 @@ export class UploadComponentActionComponent {
   private readonly registry = inject(CustomComponentRegistry);
   private readonly customComponentService = inject(CustomComponentService);
   private readonly userService = inject(UserService);
+  private readonly dialogService = inject(DialogService);
+  private readonly transloco = inject(TranslocoService);
 
   private readonly resolved = computed(() => {
     this.registry.revision(); // recompute after a promotion flips the source
@@ -56,9 +68,35 @@ export class UploadComponentActionComponent {
   );
 
   protected upload(): void {
-    const masterTypeId = this.resolved()?.masterTypeId;
-    if (masterTypeId !== undefined) {
-      void this.customComponentService.uploadComponent(masterTypeId);
-    }
+    const resolved = this.resolved();
+    if (!resolved) return;
+    const { masterTypeId, master } = resolved;
+
+    const ref = this.dialogService.open(UploadComponentDialogComponent, {
+      header: this.transloco.translate('uploadComponent.dialogHeader'),
+      width: '28rem',
+      modal: true,
+      closable: true,
+      data: {
+        masterTypeId,
+        name: master.name
+      } satisfies UploadComponentDialogData
+    });
+    if (!ref) return;
+
+    ref.onClose.subscribe((result?: UploadComponentDialogResult) => {
+      if (!result) return;
+      if (result.withDependencies) {
+        void this.customComponentService.uploadComponentWithDependencies(
+          masterTypeId,
+          result.isPublic
+        );
+      } else {
+        void this.customComponentService.uploadComponent(
+          masterTypeId,
+          result.isPublic
+        );
+      }
+    });
   }
 }

--- a/logigator-editor-v2/src/app/components/custom/actions/upload-component-action.component.ts
+++ b/logigator-editor-v2/src/app/components/custom/actions/upload-component-action.component.ts
@@ -1,0 +1,64 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input
+} from '@angular/core';
+import { Button } from 'primeng/button';
+import { Tooltip } from 'primeng/tooltip';
+import { ComponentActionContext } from '../../component-action';
+import { CustomComponentRegistry } from '../custom-component-registry.service';
+import { CustomComponentService } from '../../../custom-component/custom-component.service';
+import { UserService } from '../../../user/user.service';
+
+/**
+ * Renderer for {@link UploadComponentAction}: a button shown only when the
+ * selected instance resolves to a **local** master, which uploads (moves) that
+ * master to the user's cloud library. Disabled with a hint when signed out.
+ * Self-contained — owns its own visibility, auth gating and dispatch.
+ */
+@Component({
+  selector: 'app-upload-component-action',
+  imports: [Button, Tooltip],
+  template: `@if (visible()) {
+    <p-button
+      size="small"
+      icon="ph ph-cloud-arrow-up"
+      label="Upload to cloud"
+      class="float-right"
+      [disabled]="!authenticated()"
+      [pTooltip]="authenticated() ? '' : 'Sign in to upload to the cloud'"
+      tooltipPosition="top"
+      (onClick)="upload()"
+    />
+  }`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class UploadComponentActionComponent {
+  public readonly context = input.required<ComponentActionContext>();
+
+  private readonly registry = inject(CustomComponentRegistry);
+  private readonly customComponentService = inject(CustomComponentService);
+  private readonly userService = inject(UserService);
+
+  private readonly resolved = computed(() => {
+    this.registry.revision(); // recompute after a promotion flips the source
+    return this.registry.resolveMaster(this.context().component.config.type);
+  });
+
+  protected readonly visible = computed(
+    () => this.resolved()?.master.source === 'browser'
+  );
+
+  protected readonly authenticated = computed(
+    () => this.userService.user() !== null
+  );
+
+  protected upload(): void {
+    const masterTypeId = this.resolved()?.masterTypeId;
+    if (masterTypeId !== undefined) {
+      void this.customComponentService.uploadComponent(masterTypeId);
+    }
+  }
+}

--- a/logigator-editor-v2/src/app/components/custom/actions/upload-component.component-action.ts
+++ b/logigator-editor-v2/src/app/components/custom/actions/upload-component.component-action.ts
@@ -1,0 +1,8 @@
+import { Type } from '@angular/core';
+import { ComponentAction } from '../../component-action';
+import { UploadComponentActionComponent } from './upload-component-action.component';
+
+/** Inspector action: upload (move) a local custom component to the cloud library. */
+export class UploadComponentAction extends ComponentAction {
+  public readonly renderer: Type<unknown> = UploadComponentActionComponent;
+}

--- a/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.spec.ts
+++ b/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.spec.ts
@@ -347,6 +347,28 @@ describe('CustomComponentRegistry', () => {
       });
       expect(registry.getDefinition(snap.typeId)?.circuit).toBeUndefined();
     });
+
+    it('recomputes the master library dependencies from the new circuit', () => {
+      // The dependency graph is now derived here (not only by DefinitionBinding),
+      // so any path that sets a circuit — including lazy cloud hydration — keeps
+      // cycle detection correct.
+      const b = registry.createMaster({ id: 'b-id', symbol: 'B' }, 'browser');
+      const bSnap = registry.snapshot(b);
+      const a = registry.createMaster({ symbol: 'A' }, 'browser');
+
+      registry.setMasterCircuit(a, {
+        components: [{ type: bSnap.typeId, pos: [0, 0], options: {} }],
+        wires: []
+      });
+      expect([...registry.dependenciesOf(a)]).toEqual([b]);
+
+      // A built-in placement (no registry def) contributes no edge.
+      registry.setMasterCircuit(a, {
+        components: [{ type: 1, pos: [0, 0], options: {} }],
+        wires: []
+      });
+      expect([...registry.dependenciesOf(a)]).toEqual([]);
+    });
   });
 
   describe('ingestSnapshots', () => {
@@ -475,7 +497,10 @@ describe('CustomComponentRegistry', () => {
   describe('promoteMaster', () => {
     it('flips source/id/version and bumps the revision', () => {
       const before = registry.revision();
-      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      const m = registry.createMaster(
+        { id: 'local-1', symbol: 'M' },
+        'browser'
+      );
       registry.promoteMaster(m, 'server-1', 7);
 
       const def = registry.getDefinition(m)!;
@@ -486,7 +511,10 @@ describe('CustomComponentRegistry', () => {
     });
 
     it('re-points the id index to the new id and keeps the old id resolvable', () => {
-      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      const m = registry.createMaster(
+        { id: 'local-1', symbol: 'M' },
+        'browser'
+      );
       registry.promoteMaster(m, 'server-1', 1);
 
       // New id resolves directly; old id resolves through the alias.
@@ -495,7 +523,10 @@ describe('CustomComponentRegistry', () => {
     });
 
     it('lets a snapshot taken before promotion still resolve to the master', () => {
-      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      const m = registry.createMaster(
+        { id: 'local-1', symbol: 'M' },
+        'browser'
+      );
       const snapType = registry.snapshot(m).typeId; // captures id 'local-1'
       registry.promoteMaster(m, 'server-1', 1);
 
@@ -505,13 +536,19 @@ describe('CustomComponentRegistry', () => {
     });
 
     it('re-registers the config so the palette reflects the new source', () => {
-      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      const m = registry.createMaster(
+        { id: 'local-1', symbol: 'M' },
+        'browser'
+      );
       registry.promoteMaster(m, 'server-1', 1);
       expect(provider.getComponent(m)?.source).toBe('server');
     });
 
     it('no-ops for a snapshot or unknown type id', () => {
-      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      const m = registry.createMaster(
+        { id: 'local-1', symbol: 'M' },
+        'browser'
+      );
       const snapType = registry.snapshot(m).typeId;
       registry.promoteMaster(snapType, 'x', 1);
       registry.promoteMaster(123_456, 'x', 1);
@@ -521,9 +558,20 @@ describe('CustomComponentRegistry', () => {
 
   describe('registerIdAlias', () => {
     it('resolves an aliased id to the current master', () => {
-      const m = registry.createMaster({ id: 'server-1', symbol: 'M' }, 'server');
+      const m = registry.createMaster(
+        { id: 'server-1', symbol: 'M' },
+        'server'
+      );
       registry.registerIdAlias('old-local-1', 'server-1');
       expect(registry.masterTypeIdForId('old-local-1')).toBe(m);
+    });
+
+    it('marks the old id as promoted and bumps the revision', () => {
+      const before = registry.revision();
+      registry.registerIdAlias('old-local-1', 'server-1');
+      expect(registry.isPromotedId('old-local-1')).toBe(true);
+      expect(registry.isPromotedId('server-1')).toBe(false);
+      expect(registry.revision()).toBeGreaterThan(before);
     });
   });
 });

--- a/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.spec.ts
+++ b/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.spec.ts
@@ -448,4 +448,82 @@ describe('CustomComponentRegistry', () => {
       });
     });
   });
+
+  describe('resolveMaster', () => {
+    it('returns a master directly', () => {
+      const m = registry.createMaster({ id: 'm-1', symbol: 'M' }, 'browser');
+      expect(registry.resolveMaster(m)).toEqual({
+        masterTypeId: m,
+        master: registry.getDefinition(m)
+      });
+    });
+
+    it('follows a snapshot to its master via provenance', () => {
+      const m = registry.createMaster({ id: 'm-1', symbol: 'M' }, 'browser');
+      const snapType = registry.snapshot(m).typeId;
+      const resolved = registry.resolveMaster(snapType);
+      expect(resolved?.masterTypeId).toBe(m);
+      expect(resolved?.master.kind).toBe('master');
+    });
+
+    it('returns undefined for a built-in / unknown type id', () => {
+      expect(registry.resolveMaster(1)).toBeUndefined();
+      expect(registry.resolveMaster(999_999)).toBeUndefined();
+    });
+  });
+
+  describe('promoteMaster', () => {
+    it('flips source/id/version and bumps the revision', () => {
+      const before = registry.revision();
+      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      registry.promoteMaster(m, 'server-1', 7);
+
+      const def = registry.getDefinition(m)!;
+      expect(def.source).toBe('server');
+      expect(def.id).toBe('server-1');
+      expect(def.version).toBe(7);
+      expect(registry.revision()).toBeGreaterThan(before);
+    });
+
+    it('re-points the id index to the new id and keeps the old id resolvable', () => {
+      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      registry.promoteMaster(m, 'server-1', 1);
+
+      // New id resolves directly; old id resolves through the alias.
+      expect(registry.masterTypeIdForId('server-1')).toBe(m);
+      expect(registry.masterTypeIdForId('local-1')).toBe(m);
+    });
+
+    it('lets a snapshot taken before promotion still resolve to the master', () => {
+      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      const snapType = registry.snapshot(m).typeId; // captures id 'local-1'
+      registry.promoteMaster(m, 'server-1', 1);
+
+      const resolved = registry.resolveMaster(snapType);
+      expect(resolved?.masterTypeId).toBe(m);
+      expect(resolved?.master.source).toBe('server');
+    });
+
+    it('re-registers the config so the palette reflects the new source', () => {
+      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      registry.promoteMaster(m, 'server-1', 1);
+      expect(provider.getComponent(m)?.source).toBe('server');
+    });
+
+    it('no-ops for a snapshot or unknown type id', () => {
+      const m = registry.createMaster({ id: 'local-1', symbol: 'M' }, 'browser');
+      const snapType = registry.snapshot(m).typeId;
+      registry.promoteMaster(snapType, 'x', 1);
+      registry.promoteMaster(123_456, 'x', 1);
+      expect(registry.getDefinition(m)?.source).toBe('browser');
+    });
+  });
+
+  describe('registerIdAlias', () => {
+    it('resolves an aliased id to the current master', () => {
+      const m = registry.createMaster({ id: 'server-1', symbol: 'M' }, 'server');
+      registry.registerIdAlias('old-local-1', 'server-1');
+      expect(registry.masterTypeIdForId('old-local-1')).toBe(m);
+    });
+  });
 });

--- a/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.ts
+++ b/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.ts
@@ -225,10 +225,13 @@ export class CustomComponentRegistry {
   }
 
   /**
-   * Materialises a **master's** own circuit from its open editor (see
-   * `DefinitionBinding`). Replaces `circuit` with a fresh deep copy rather than
-   * mutating in place, so snapshots taken earlier (which copied the previous
-   * object) stay frozen. No-ops for a snapshot or unknown type id.
+   * Materialises a **master's** own circuit (from its open editor — see
+   * `DefinitionBinding` — or a lazily-fetched cloud circuit). Replaces `circuit`
+   * with a fresh deep copy rather than mutating in place, so snapshots taken
+   * earlier (which copied the previous object) stay frozen, and recomputes the
+   * master's direct library dependencies from the new circuit so cycle detection
+   * stays correct for any path that sets a circuit (not just an open editor).
+   * No-ops for a snapshot or unknown type id.
    */
   public setMasterCircuit(
     masterTypeId: number,
@@ -238,6 +241,27 @@ export class CustomComponentRegistry {
     if (!def || def.kind !== 'master') return;
     def.circuit = cloneCircuit(circuit);
     this._masterToSnapshotTypeId.delete(masterTypeId);
+    this._recomputeDependencies(masterTypeId, circuit);
+  }
+
+  /**
+   * Derives a master's direct library dependencies (the distinct master type ids
+   * behind the custom snapshots its circuit places, resolved through the promotion
+   * alias) and records them for cycle prevention. Built-ins (no registry def) and
+   * unresolvable types contribute no edge.
+   */
+  private _recomputeDependencies(
+    masterTypeId: number,
+    circuit: SerializedCircuitBody
+  ): void {
+    const deps = new Set<number>();
+    for (const c of circuit.components) {
+      const childId = this._definitions.get(c.type)?.id;
+      if (childId === undefined) continue;
+      const dependencyMaster = this.masterTypeIdForId(childId);
+      if (dependencyMaster !== undefined) deps.add(dependencyMaster);
+    }
+    this._dependencies.set(masterTypeId, deps);
   }
 
   /**
@@ -274,10 +298,22 @@ export class CustomComponentRegistry {
 
   /**
    * Records an old-id -> current-id alias (idempotent). Used at startup to hydrate
-   * the alias map from the persistent id-map so promotions survive a reload.
+   * the alias map from the persistent id-map so promotions survive a reload. Bumps
+   * the revision so signal readers that resolved before the aliases loaded
+   * re-resolve once they are in place.
    */
   public registerIdAlias(oldId: string, newId: string): void {
     this._idAliases.set(oldId, newId);
+    this._revision.update((r) => r + 1);
+  }
+
+  /**
+   * Whether `id` is a recorded pre-promotion (old) id — i.e. a browser master
+   * with this id was uploaded to the cloud. The startup browser preload uses this
+   * to ignore a stale local record left behind by a partially-failed promotion.
+   */
+  public isPromotedId(id: string): boolean {
+    return this._idAliases.has(id);
   }
 
   /**

--- a/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.ts
+++ b/logigator-editor-v2/src/app/components/custom/custom-component-registry.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { filter, Observable, Subject } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 import { ComponentProviderService } from '../component-provider.service';
@@ -45,6 +45,11 @@ export class CustomComponentRegistry {
   // Masters only: persistent id -> masterTypeId. Snapshots are excluded — one id
   // maps to many snapshot type ids, so the reverse lookup is masters-only.
   private readonly _idToMasterTypeId = new Map<string, number>();
+  // Old (pre-promotion) id -> current id. A master promoted browser->server keeps
+  // its old local id here so snapshots that captured it still resolve to the
+  // now-server master. Populated live by promoteMaster and at startup from the
+  // persistent id-map (registerIdAlias).
+  private readonly _idAliases = new Map<string, string>();
   // Library dependency edges: masterTypeId -> the distinct master type ids its
   // circuit places. Reverse-traversed by dependentsOf for cycle filtering.
   private readonly _dependencies = new Map<number, Set<number>>();
@@ -53,6 +58,12 @@ export class CustomComponentRegistry {
   // master content so subsequent placements get a fresh snapshot.
   private readonly _masterToSnapshotTypeId = new Map<number, number>();
   private readonly _change$ = new Subject<CustomComponentDefinition>();
+  // Bumped on mutations that change a master's identity/source (currently
+  // promotion). Lets signal-based readers (the settings panel chip + upload
+  // button) recompute a master's resolved source after an upload-to-cloud.
+  private readonly _revision = signal(0);
+  /** Increments whenever a master is promoted; a dependency for reactive readers. */
+  public readonly revision = this._revision.asReadonly();
 
   /**
    * Registers a new editable library **master** and returns its type id. A
@@ -247,9 +258,74 @@ export class CustomComponentRegistry {
     return this._definitions.get(typeId);
   }
 
-  /** Masters-only reverse lookup: persistent id -> masterTypeId. */
+  /**
+   * Masters-only reverse lookup: persistent id -> masterTypeId. Falls back
+   * through the promotion alias map, so an id captured before an upload-to-cloud
+   * still resolves to the (now-server) master under its new id.
+   */
   public masterTypeIdForId(id: string): number | undefined {
-    return this._idToMasterTypeId.get(id);
+    const direct = this._idToMasterTypeId.get(id);
+    if (direct !== undefined) return direct;
+    const aliased = this._idAliases.get(id);
+    return aliased !== undefined
+      ? this._idToMasterTypeId.get(aliased)
+      : undefined;
+  }
+
+  /**
+   * Records an old-id -> current-id alias (idempotent). Used at startup to hydrate
+   * the alias map from the persistent id-map so promotions survive a reload.
+   */
+  public registerIdAlias(oldId: string, newId: string): void {
+    this._idAliases.set(oldId, newId);
+  }
+
+  /**
+   * Resolves any custom type id to its master entry: a master returns itself, a
+   * snapshot follows its provenance id (through the promotion alias). Returns
+   * undefined for a built-in, unknown, or unresolvable type id.
+   */
+  public resolveMaster(
+    typeId: number
+  ): { masterTypeId: number; master: CustomComponentDefinition } | undefined {
+    const def = this._definitions.get(typeId);
+    if (!def) return undefined;
+    if (def.kind === 'master') return { masterTypeId: typeId, master: def };
+    if (def.id === undefined) return undefined;
+    const masterTypeId = this.masterTypeIdForId(def.id);
+    if (masterTypeId === undefined) return undefined;
+    const master = this._definitions.get(masterTypeId);
+    return master ? { masterTypeId, master } : undefined;
+  }
+
+  /**
+   * Promotes a **browser** master to the server library after its content has
+   * been saved server-side: flips `source`/`id`/`version`, re-points the masters
+   * id index to the new id while keeping the old id as an alias (so snapshots that
+   * already captured it still resolve), invalidates the placement-snapshot cache,
+   * re-registers the config (so the palette reflects the new source) and bumps the
+   * revision. No-op for a snapshot or unknown type id.
+   */
+  public promoteMaster(
+    masterTypeId: number,
+    newId: string,
+    version: number
+  ): void {
+    const def = this._definitions.get(masterTypeId);
+    if (!def || def.kind !== 'master') return;
+    const oldId = def.id;
+    if (oldId !== undefined) {
+      this._idToMasterTypeId.delete(oldId);
+      this._idAliases.set(oldId, newId);
+    }
+    def.source = 'server';
+    def.id = newId;
+    def.version = version;
+    this._idToMasterTypeId.set(newId, masterTypeId);
+    this._masterToSnapshotTypeId.delete(masterTypeId);
+    this._provider.register(buildCustomComponentConfig(def));
+    this._revision.update((r) => r + 1);
+    this._change$.next(def);
   }
 
   /** A snapshot's `source.id` provenance, or a master's own id. */

--- a/logigator-editor-v2/src/app/components/custom/custom-component.config.ts
+++ b/logigator-editor-v2/src/app/components/custom/custom-component.config.ts
@@ -6,6 +6,7 @@ import { CustomComponentDefinition } from './custom-component-definition.model';
 import { CustomComponent } from './custom-component';
 import { EditComponentAction } from './actions/edit-component.component-action';
 import { UpdateInstanceComponentAction } from './actions/update-instance.component-action';
+import { UploadComponentAction } from './actions/upload-component.component-action';
 
 /**
  * Option set for every custom component instance. Unlike built-ins, a custom
@@ -43,6 +44,11 @@ export function buildCustomComponentConfig(
     get symbol(): string {
       return def.symbol;
     },
+    // Live view of the definition's library, so the palette tile's cloud/local
+    // indicator tracks an upload-to-cloud promotion without rebuilding the config.
+    get source(): 'server' | 'browser' {
+      return def.source;
+    },
     // User-authored strings, shown verbatim (the literal arm of LocalizableText)
     // rather than resolved against the translation schema.
     get name(): LocalizableText {
@@ -57,7 +63,11 @@ export function buildCustomComponentConfig(
     // Inspector actions for a placed instance: open its master, and (when behind)
     // pull the latest. Rendered generically by the settings panel; only a
     // selected snapshot instance ever surfaces them.
-    actions: [new EditComponentAction(), new UpdateInstanceComponentAction()],
+    actions: [
+      new EditComponentAction(),
+      new UpdateInstanceComponentAction(),
+      new UploadComponentAction()
+    ],
     create: (options) => new CustomComponent(options, def, config)
   };
   return config;

--- a/logigator-editor-v2/src/app/custom-component/custom-component.service.ts
+++ b/logigator-editor-v2/src/app/custom-component/custom-component.service.ts
@@ -9,6 +9,8 @@ import { CustomComponent } from '../components/custom/custom-component';
 import { Action } from '../actions/action';
 import { UpdateInstanceAction } from '../actions/actions/update-instance.action';
 import { ToastService } from '../logging/toast.service';
+import { ConfirmationService } from 'primeng/api';
+import { UserService } from '../user/user.service';
 import { DefinitionBinding } from './definition-binding';
 
 export interface NewComponentMeta {
@@ -39,6 +41,8 @@ export class CustomComponentService {
   private readonly metadataStore = inject(ProjectMetadataStore);
   private readonly persistence = inject(PersistenceService);
   private readonly toast = inject(ToastService);
+  private readonly confirmation = inject(ConfirmationService);
+  private readonly user = inject(UserService);
 
   private readonly _bindings = new Map<Project, DefinitionBinding>();
 
@@ -185,6 +189,67 @@ export class CustomComponentService {
     // real instance is created by the action's add on do(). Drop this one.
     replacement.destroy({ children: true });
     return action;
+  }
+
+  /**
+   * Uploads (moves) a local master to the user's cloud library. Requires being
+   * signed in. When the component embeds other local components, a confirmation
+   * first lists them — they ride along as embedded copies and stay in the local
+   * library; only the chosen component moves to the cloud. A no-dependency upload
+   * proceeds straight away.
+   */
+  public async uploadComponent(masterTypeId: number): Promise<void> {
+    const def = this.registry.getDefinition(masterTypeId);
+    if (!def || def.kind !== 'master' || def.source !== 'browser') return;
+
+    if (this.user.user() === null) {
+      this.toast.error('Sign in to upload components to the cloud');
+      return;
+    }
+
+    let deps: string[];
+    try {
+      deps = await this.persistence.localDependencyNames(masterTypeId);
+    } catch {
+      deps = [];
+    }
+
+    const run = async (): Promise<void> => {
+      try {
+        await this.persistence.promoteComponentToServer(masterTypeId);
+        this.toast.success('Component uploaded to the cloud');
+      } catch {
+        this.toast.error('Failed to upload component');
+      }
+    };
+
+    if (deps.length === 0) {
+      await run();
+      return;
+    }
+
+    this.confirmation.confirm({
+      header: 'Upload to cloud',
+      message:
+        `“${def.name}” uses these local components, which will be uploaded ` +
+        `as copies (they stay in your local library):\n\n${deps
+          .map((d) => `• ${d}`)
+          .join('\n')}`,
+      acceptLabel: 'Upload',
+      rejectLabel: 'Cancel',
+      rejectButtonProps: { severity: 'secondary', outlined: true },
+      accept: () => void run()
+    });
+  }
+
+  /**
+   * Ensures a master's circuit is loaded before it is placed or updated. Cloud
+   * masters are preloaded summary-only (no circuit); this lazily fetches the
+   * circuit on first use. No-op for built-ins, browser masters, and already-loaded
+   * masters.
+   */
+  public ensureMasterCircuit(masterTypeId: number): Promise<void> {
+    return this.persistence.ensureServerMasterCircuit(masterTypeId);
   }
 
   private _findOpenEditor(masterId: string): Project | undefined {

--- a/logigator-editor-v2/src/app/custom-component/custom-component.service.ts
+++ b/logigator-editor-v2/src/app/custom-component/custom-component.service.ts
@@ -246,10 +246,18 @@ export class CustomComponentService {
    * Ensures a master's circuit is loaded before it is placed or updated. Cloud
    * masters are preloaded summary-only (no circuit); this lazily fetches the
    * circuit on first use. No-op for built-ins, browser masters, and already-loaded
-   * masters.
+   * masters. Returns whether the circuit is ready: a failed cloud fetch shows a
+   * toast and returns `false` so the caller can abort (rather than arm placement /
+   * apply an update against empty content).
    */
-  public ensureMasterCircuit(masterTypeId: number): Promise<void> {
-    return this.persistence.ensureServerMasterCircuit(masterTypeId);
+  public async ensureMasterCircuit(masterTypeId: number): Promise<boolean> {
+    try {
+      await this.persistence.ensureServerMasterCircuit(masterTypeId);
+      return true;
+    } catch {
+      this.toast.error('Failed to load component from the cloud');
+      return false;
+    }
   }
 
   private _findOpenEditor(masterId: string): Project | undefined {

--- a/logigator-editor-v2/src/app/custom-component/custom-component.service.ts
+++ b/logigator-editor-v2/src/app/custom-component/custom-component.service.ts
@@ -9,7 +9,7 @@ import { CustomComponent } from '../components/custom/custom-component';
 import { Action } from '../actions/action';
 import { UpdateInstanceAction } from '../actions/actions/update-instance.action';
 import { ToastService } from '../logging/toast.service';
-import { ConfirmationService } from 'primeng/api';
+import { TranslocoService } from '@jsverse/transloco';
 import { UserService } from '../user/user.service';
 import { DefinitionBinding } from './definition-binding';
 
@@ -41,7 +41,7 @@ export class CustomComponentService {
   private readonly metadataStore = inject(ProjectMetadataStore);
   private readonly persistence = inject(PersistenceService);
   private readonly toast = inject(ToastService);
-  private readonly confirmation = inject(ConfirmationService);
+  private readonly transloco = inject(TranslocoService);
   private readonly user = inject(UserService);
 
   private readonly _bindings = new Map<Project, DefinitionBinding>();
@@ -192,54 +192,106 @@ export class CustomComponentService {
   }
 
   /**
-   * Uploads (moves) a local master to the user's cloud library. Requires being
-   * signed in. When the component embeds other local components, a confirmation
-   * first lists them — they ride along as embedded copies and stay in the local
-   * library; only the chosen component moves to the cloud. A no-dependency upload
-   * proceeds straight away.
+   * The local components embedded in a master (transitively), each with its master
+   * type id when it is still a registered browser master (`null` when it only
+   * survives embedded). Used to warn the user before an upload that they ride along
+   * as copies, and to drive "upload with dependencies". Empty when the lookup fails.
    */
-  public async uploadComponent(masterTypeId: number): Promise<void> {
+  public async localDependencies(
+    masterTypeId: number
+  ): Promise<{ name: string; masterTypeId: number | null }[]> {
+    try {
+      return await this.persistence.localDependencies(masterTypeId);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Uploads (moves) a local master to the user's cloud library at the chosen
+   * visibility. Requires being signed in. Embedded local components ride along as
+   * copies and stay in the local library; only the chosen component moves to the
+   * cloud. The caller is responsible for confirming with the user first.
+   */
+  public async uploadComponent(
+    masterTypeId: number,
+    isPublic = false
+  ): Promise<void> {
     const def = this.registry.getDefinition(masterTypeId);
     if (!def || def.kind !== 'master' || def.source !== 'browser') return;
 
     if (this.user.user() === null) {
-      this.toast.error('Sign in to upload components to the cloud');
+      this.toast.error(
+        this.transloco.translate('uploadComponent.signInRequired')
+      );
       return;
     }
 
-    let deps: string[];
     try {
-      deps = await this.persistence.localDependencyNames(masterTypeId);
+      await this.persistence.promoteComponentToServer(masterTypeId, isPublic);
+      this.toast.success(this.transloco.translate('uploadComponent.success'));
     } catch {
-      deps = [];
+      this.toast.error(this.transloco.translate('uploadComponent.failure'));
     }
+  }
 
-    const run = async (): Promise<void> => {
-      try {
-        await this.persistence.promoteComponentToServer(masterTypeId);
-        this.toast.success('Component uploaded to the cloud');
-      } catch {
-        this.toast.error('Failed to upload component');
-      }
-    };
+  /**
+   * Uploads a local master **and** each resolvable local dependency to the cloud as
+   * separate library entries, all at the chosen visibility. The server model has no
+   * linking, so every entry stays self-contained (the master still embeds its own
+   * copies); the dependencies simply also appear in the user's cloud library.
+   *
+   * The master is uploaded first — it is the primary intent and self-contained, so
+   * if it fails nothing else is attempted. Dependencies are then uploaded
+   * best-effort: each is independent and individually irreversible, so a single
+   * failure is reported as a count rather than unwinding the rest.
+   */
+  public async uploadComponentWithDependencies(
+    masterTypeId: number,
+    isPublic = false
+  ): Promise<void> {
+    const def = this.registry.getDefinition(masterTypeId);
+    if (!def || def.kind !== 'master' || def.source !== 'browser') return;
 
-    if (deps.length === 0) {
-      await run();
+    if (this.user.user() === null) {
+      this.toast.error(
+        this.transloco.translate('uploadComponent.signInRequired')
+      );
       return;
     }
 
-    this.confirmation.confirm({
-      header: 'Upload to cloud',
-      message:
-        `“${def.name}” uses these local components, which will be uploaded ` +
-        `as copies (they stay in your local library):\n\n${deps
-          .map((d) => `• ${d}`)
-          .join('\n')}`,
-      acceptLabel: 'Upload',
-      rejectLabel: 'Cancel',
-      rejectButtonProps: { severity: 'secondary', outlined: true },
-      accept: () => void run()
-    });
+    // Resolve the dependency ids *before* promoting the master — promotion deletes
+    // the master's browser record, which is where the dependency list is read from.
+    const dependencyIds = (await this.localDependencies(masterTypeId))
+      .map((d) => d.masterTypeId)
+      .filter((id): id is number => id !== null);
+
+    try {
+      await this.persistence.promoteComponentToServer(masterTypeId, isPublic);
+    } catch {
+      this.toast.error(this.transloco.translate('uploadComponent.failure'));
+      return;
+    }
+
+    let failed = 0;
+    for (const id of dependencyIds) {
+      try {
+        await this.persistence.promoteComponentToServer(id, isPublic);
+      } catch {
+        failed++;
+      }
+    }
+
+    if (failed > 0) {
+      this.toast.warn(
+        this.transloco.translate('uploadComponent.partialFailure', {
+          failed,
+          total: dependencyIds.length
+        })
+      );
+    } else {
+      this.toast.success(this.transloco.translate('uploadComponent.success'));
+    }
   }
 
   /**

--- a/logigator-editor-v2/src/app/custom-component/definition-binding.ts
+++ b/logigator-editor-v2/src/app/custom-component/definition-binding.ts
@@ -1,6 +1,5 @@
 import { auditTime, Subscription } from 'rxjs';
 import { Project } from '../project/project';
-import { CustomComponent } from '../components/custom/custom-component';
 import { CustomComponentRegistry } from '../components/custom/custom-component-registry.service';
 import { serializeProjectBody } from '../persistence/snapshots';
 import { deriveSummary } from './definition-derivation';
@@ -41,24 +40,12 @@ export class DefinitionBinding {
 
     // Materialise the master's circuit so a snapshot taken at place/update time
     // carries the current contents. Snapshots deep-copy it, so this never
-    // touches already-placed frozen instances.
+    // touches already-placed frozen instances. `setMasterCircuit` also recomputes
+    // the master's library dependencies from the circuit (for cycle prevention).
     this.registry.setMasterCircuit(
       this.masterTypeId,
       serializeProjectBody(this.project)
     );
-
-    // A master's library dependencies are the distinct masters behind the
-    // snapshots it places (provenance via source.id). Frozen snapshots add no
-    // edges of their own; only placing master X into this one creates X → this.
-    const deps = new Set<number>();
-    for (const component of this.project.components) {
-      if (!(component instanceof CustomComponent)) continue;
-      const def = this.registry.getDefinition(component.config.type);
-      if (def?.id === undefined) continue;
-      const dependencyMaster = this.registry.masterTypeIdForId(def.id);
-      if (dependencyMaster !== undefined) deps.add(dependencyMaster);
-    }
-    this.registry.setDependencies(this.masterTypeId, deps);
   }
 
   public dispose(): void {

--- a/logigator-editor-v2/src/app/persistence/browser/component-id-map.store.ts
+++ b/logigator-editor-v2/src/app/persistence/browser/component-id-map.store.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import {
+  COMPONENT_ID_MAP_STORE,
+  IndexedDbStore
+} from '../../storage/indexed-db-store';
+
+/**
+ * One persisted alias: a master's old (pre-promotion) local id and the server id
+ * it was promoted to. `lastEdited` exists only to satisfy the shared
+ * {@link IndexedDbStore} record shape (the store's ordered-listing index).
+ */
+export interface StoredComponentIdMapping {
+  /** The old (pre-promotion) local id — the store key. */
+  id: string;
+  /** The server id the component was promoted to. */
+  newId: string;
+  lastEdited: number;
+}
+
+/**
+ * Durable old-local-id → server-id alias map, written when a browser master is
+ * promoted to the cloud ({@link PersistenceService.promoteComponentToServer}).
+ * Loaded into the registry at startup so snapshots embedded before the promotion
+ * still resolve to the now-server master (their captured id is the old local id).
+ */
+@Injectable({ providedIn: 'root' })
+export class ComponentIdMapStore {
+  private readonly _store = new IndexedDbStore<StoredComponentIdMapping>(
+    COMPONENT_ID_MAP_STORE
+  );
+
+  put(oldId: string, newId: string): Promise<void> {
+    return this._store.put({ id: oldId, newId, lastEdited: Date.now() });
+  }
+
+  list(): Promise<StoredComponentIdMapping[]> {
+    return this._store.listByLastEdited();
+  }
+}

--- a/logigator-editor-v2/src/app/persistence/file/circuit-file.service.ts
+++ b/logigator-editor-v2/src/app/persistence/file/circuit-file.service.ts
@@ -225,7 +225,17 @@ export class CircuitFileService {
     } catch {
       throw new InvalidFileError('Malformed JSON');
     }
-    const file = migrateToCurrent(parsed, this.migrationContext);
+    return this.decodeToBodyFromData(parsed);
+  }
+
+  /**
+   * The object-level form of {@link decodeToBody}: migrates an already-parsed
+   * document (e.g. a server response wrapped via `server.toCircuitFileV0`),
+   * ingests its embedded snapshots and returns the remapped body — no JSON parse,
+   * no live instances. Used by the startup preload of server masters.
+   */
+  decodeToBodyFromData(data: unknown): SerializedCircuitBody {
+    const file = migrateToCurrent(data, this.migrationContext);
     const remap = this.registry.ingestSnapshots(
       this._asArray(file.definitions, 'definitions')
     );

--- a/logigator-editor-v2/src/app/persistence/file/circuit-file.service.ts
+++ b/logigator-editor-v2/src/app/persistence/file/circuit-file.service.ts
@@ -14,7 +14,8 @@ import { InvalidFileError } from './circuit-file.errors';
 import { CURRENT_FILE_VERSION, CurrentCircuitFile } from './circuit-file.types';
 import {
   remapComponentTypes,
-  SerializedCircuitBody
+  SerializedCircuitBody,
+  SnapshotDefinition
 } from '../serialized-circuit';
 import { collectSnapshots, serializeProjectBody } from '../snapshots';
 
@@ -246,6 +247,24 @@ export class CircuitFileService {
       ),
       wires: this._asArray(file.wires, 'wires')
     };
+  }
+
+  /**
+   * Parses and migrates a stored circuit and returns its embedded snapshot
+   * definitions **without ingesting them into the registry** — a read-only peek
+   * for inspecting a component's dependencies (e.g. the upload-to-cloud
+   * confirmation). Builds no live instances and allocates no type ids, so unlike
+   * {@link decodeToBody} it leaves the registry untouched.
+   */
+  peekDefinitions(content: string): SnapshotDefinition[] {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      throw new InvalidFileError('Malformed JSON');
+    }
+    const file = migrateToCurrent(parsed, this.migrationContext);
+    return this._asArray(file.definitions, 'definitions');
   }
 
   private _asArray<T>(value: T[] | undefined, field: string): T[] {

--- a/logigator-editor-v2/src/app/persistence/persistence.service.spec.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.spec.ts
@@ -1283,6 +1283,127 @@ describe('PersistenceService', () => {
       ).rejects.toThrow();
     });
 
+    it('promoteComponentToServer succeeds (no throw) even if the local cleanup fails after the upload', async () => {
+      const circuitFile = TestBed.inject(CircuitFileService);
+      await componentStore.save({
+        id: 'local-1',
+        version: 1,
+        name: 'Comp',
+        symbol: 'C',
+        description: '',
+        numInputs: 0,
+        numOutputs: 0,
+        labels: [],
+        content: circuitFile.toJson(new Project(), 'Comp')
+      });
+      const masterTypeId = registry.createMaster(
+        { id: 'local-1', symbol: 'C', name: 'Comp' },
+        'browser'
+      );
+      // The upload has already committed server-side when the local record delete
+      // fails — the operation must NOT surface as a failure (that would lie and
+      // hide the now-disabled retry).
+      vi.spyOn(componentStore, 'delete').mockRejectedValue(new Error('boom'));
+      const tick = () => new Promise((r) => setTimeout(r, 0));
+
+      const promise = service.promoteComponentToServer(masterTypeId);
+      await tick();
+      httpMock
+        .expectOne(COMPONENTS_URL)
+        .flush(componentSummaryResponse({ id: 'srv-comp', hash: 'h0' }));
+      await tick();
+      httpMock
+        .expectOne(COMPONENT_URL('srv-comp'))
+        .flush(componentSummaryResponse({ id: 'srv-comp', version: 5 }));
+
+      await expect(promise).resolves.toBeUndefined();
+      const def = registry.getDefinition(masterTypeId)!;
+      expect(def.source).toBe('server');
+      // The durable alias was written before the (failed) delete, so a reload
+      // self-heals (the browser preload skips the orphaned record).
+      expect(idMapStore.records.get('local-1')).toBe('srv-comp');
+    });
+
+    it('promoteComponentToServer re-points an open editor of the master to the new server identity', async () => {
+      const circuitFile = TestBed.inject(CircuitFileService);
+      await componentStore.save({
+        id: 'local-1',
+        version: 1,
+        name: 'Comp',
+        symbol: 'C',
+        description: '',
+        numInputs: 0,
+        numOutputs: 0,
+        labels: [],
+        content: circuitFile.toJson(new Project(), 'Comp')
+      });
+      const masterTypeId = registry.createMaster(
+        { id: 'local-1', symbol: 'C', name: 'Comp' },
+        'browser'
+      );
+      // The master's editor tab is open (browser comp), registered under its old id.
+      const editor = new Project();
+      metadataStore.register(editor, {
+        id: 'local-1',
+        name: 'Comp',
+        type: 'comp',
+        source: 'browser',
+        hash: '',
+        isPublic: false
+      });
+      const tick = () => new Promise((r) => setTimeout(r, 0));
+
+      const promise = service.promoteComponentToServer(masterTypeId);
+      await tick();
+      httpMock
+        .expectOne(COMPONENTS_URL)
+        .flush(componentSummaryResponse({ id: 'srv-comp', hash: 'h0' }));
+      await tick();
+      httpMock
+        .expectOne(COMPONENT_URL('srv-comp'))
+        .flush(
+          componentSummaryResponse({ id: 'srv-comp', version: 5, hash: 'h2' })
+        );
+      await promise;
+
+      // The editor now points at the cloud record, so a later save routes to the
+      // server instead of re-creating the deleted browser record.
+      const meta = metadataStore.getMetadata(editor)!;
+      expect(meta.source).toBe('server');
+      expect(meta.id).toBe('srv-comp');
+      expect(meta.hash).toBe('h2');
+      editor.destroy();
+    });
+
+    it('preloadBrowserMasters skips a record whose id was promoted to the cloud', async () => {
+      const circuitFile = TestBed.inject(CircuitFileService);
+      // The cloud master and the persisted promotion alias (as hydrated at startup).
+      const serverType = registry.createMaster(
+        { id: 'srv-1', symbol: 'C', name: 'Comp' },
+        'server'
+      );
+      registry.registerIdAlias('local-1', 'srv-1');
+      // A stale local record left behind by a partially-failed promotion.
+      await componentStore.save({
+        id: 'local-1',
+        version: 1,
+        name: 'Comp',
+        symbol: 'C',
+        description: '',
+        numInputs: 0,
+        numOutputs: 0,
+        labels: [],
+        content: circuitFile.toJson(new Project(), 'Comp')
+      });
+
+      await service.preloadBrowserMasters();
+
+      // No browser duplicate: the old id still resolves through the alias to the
+      // single (server) master, instead of a freshly-registered browser dupe.
+      expect(registry.masterTypeIdForId('local-1')).toBe(serverType);
+      expect(registry.getDefinition(serverType)?.source).toBe('server');
+    });
+
     it('localDependencyNames returns [] for a master with no embedded customs', async () => {
       const circuitFile = TestBed.inject(CircuitFileService);
       await componentStore.save({
@@ -1401,7 +1522,11 @@ describe('PersistenceService', () => {
           labels: [],
           createdOn: '2024-01-01',
           lastEdited: '2024-01-01',
-          elementsFile: { hash: 'h', mimeType: 'application/json', publicUrl: '' },
+          elementsFile: {
+            hash: 'h',
+            mimeType: 'application/json',
+            publicUrl: ''
+          },
           previewDark: null,
           previewLight: null,
           public: false,

--- a/logigator-editor-v2/src/app/persistence/persistence.service.spec.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.spec.ts
@@ -16,6 +16,8 @@ import { environment } from '../../environments/environment';
 import { InvalidFileError } from './file/circuit-file.errors';
 import { BrowserProjectStore } from './browser/browser-project.store';
 import { BrowserComponentStore } from './browser/browser-component.store';
+import { ComponentIdMapStore } from './browser/component-id-map.store';
+import { CircuitFileService } from './file/circuit-file.service';
 import { CustomComponentRegistry } from '../components/custom/custom-component-registry.service';
 import { ComponentProviderService } from '../components/component-provider.service';
 import { CustomComponent } from '../components/custom/custom-component';
@@ -25,7 +27,8 @@ import { MoveComponentsAction } from '../actions/actions/move-components.action'
 import { SerializedCircuitBody } from './serialized-circuit';
 import {
   FakeBrowserComponentStore,
-  FakeBrowserProjectStore
+  FakeBrowserProjectStore,
+  FakeComponentIdMapStore
 } from '../../testing/fake-browser-stores';
 import { configureTestBed } from '../../testing/configure-test-bed';
 
@@ -131,6 +134,7 @@ describe('PersistenceService', () => {
   let locationGo: Mock;
   let browserStore: FakeBrowserProjectStore;
   let componentStore: FakeBrowserComponentStore;
+  let idMapStore: FakeComponentIdMapStore;
   let registry: CustomComponentRegistry;
   let provider: ComponentProviderService;
 
@@ -140,6 +144,7 @@ describe('PersistenceService', () => {
     locationGo = vi.fn();
     browserStore = new FakeBrowserProjectStore();
     componentStore = new FakeBrowserComponentStore();
+    idMapStore = new FakeComponentIdMapStore();
     configureTestBed([
       {
         provide: Location,
@@ -152,6 +157,7 @@ describe('PersistenceService', () => {
       },
       { provide: BrowserProjectStore, useValue: browserStore },
       { provide: BrowserComponentStore, useValue: componentStore },
+      { provide: ComponentIdMapStore, useValue: idMapStore },
       {
         provide: TranslocoService,
         useValue: {
@@ -1217,6 +1223,220 @@ describe('PersistenceService', () => {
         config.create({ direction: config.options['direction'].clone() })
       );
     }
+
+    it('promoteComponentToServer uploads a local master, flips it to server, and removes the local record', async () => {
+      // A local master with its circuit stored in the browser components store.
+      const circuitFile = TestBed.inject(CircuitFileService);
+      const content = circuitFile.toJson(new Project(), 'Comp');
+      await componentStore.save({
+        id: 'local-1',
+        version: 1,
+        name: 'Comp',
+        symbol: 'C',
+        description: '',
+        numInputs: 0,
+        numOutputs: 0,
+        labels: [],
+        content
+      });
+      const masterTypeId = registry.createMaster(
+        { id: 'local-1', symbol: 'C', name: 'Comp' },
+        'browser'
+      );
+
+      // The POST is issued only after the store read + temp-project build, so
+      // flush pending microtasks (a macrotask tick) before each HTTP expectation.
+      const tick = () => new Promise((r) => setTimeout(r, 0));
+
+      const promise = service.promoteComponentToServer(masterTypeId);
+
+      await tick();
+      const post = httpMock.expectOne(COMPONENTS_URL);
+      expect(post.request.method).toBe('POST');
+      post.flush(componentSummaryResponse({ id: 'srv-comp', hash: 'h0' }));
+
+      await tick();
+      const put = httpMock.expectOne(COMPONENT_URL('srv-comp'));
+      expect(put.request.method).toBe('PUT');
+      put.flush(componentSummaryResponse({ id: 'srv-comp', version: 5 }));
+
+      await promise;
+
+      const def = registry.getDefinition(masterTypeId)!;
+      expect(def.source).toBe('server');
+      expect(def.id).toBe('srv-comp');
+      expect(def.version).toBe(5);
+      // Old local id still resolves (alias) and was persisted to the id-map.
+      expect(registry.masterTypeIdForId('local-1')).toBe(masterTypeId);
+      expect(idMapStore.records.get('local-1')).toBe('srv-comp');
+      // The local record is gone — the component moved to the cloud.
+      expect(await componentStore.get('local-1')).toBeUndefined();
+    });
+
+    it('promoteComponentToServer rejects a server master (nothing to upload)', async () => {
+      const masterTypeId = registry.createMaster(
+        { id: 'srv-x', symbol: 'X' },
+        'server'
+      );
+      await expect(
+        service.promoteComponentToServer(masterTypeId)
+      ).rejects.toThrow();
+    });
+
+    it('localDependencyNames returns [] for a master with no embedded customs', async () => {
+      const circuitFile = TestBed.inject(CircuitFileService);
+      await componentStore.save({
+        id: 'local-2',
+        version: 1,
+        name: 'Plain',
+        symbol: 'P',
+        description: '',
+        numInputs: 0,
+        numOutputs: 0,
+        labels: [],
+        content: circuitFile.toJson(new Project(), 'Plain')
+      });
+      const masterTypeId = registry.createMaster(
+        { id: 'local-2', symbol: 'P' },
+        'browser'
+      );
+      expect(await service.localDependencyNames(masterTypeId)).toEqual([]);
+    });
+
+    it('localDependencyNames lists the local customs a master embeds', async () => {
+      const circuitFile = TestBed.inject(CircuitFileService);
+      // Local dependency master B, embedded by master A.
+      const bType = registry.createMaster(
+        { id: 'dep-b', symbol: 'B', name: 'Dep B' },
+        'browser'
+      );
+      const aProject = new Project();
+      placeSnapshot(aProject, bType);
+      const contentA = circuitFile.toJson(aProject, 'A');
+      aProject.destroy();
+
+      await componentStore.save({
+        id: 'local-a',
+        version: 1,
+        name: 'A',
+        symbol: 'A',
+        description: '',
+        numInputs: 0,
+        numOutputs: 0,
+        labels: [],
+        content: contentA
+      });
+      const aType = registry.createMaster(
+        { id: 'local-a', symbol: 'A', name: 'A' },
+        'browser'
+      );
+
+      expect(await service.localDependencyNames(aType)).toEqual(['Dep B']);
+    });
+
+    it('preloadServerMasters registers cloud masters from the list alone (no per-component fetch)', async () => {
+      const tick = () => new Promise((r) => setTimeout(r, 0));
+      const promise = service.preloadServerMasters();
+
+      await tick();
+      const list = httpMock.expectOne(COMPONENTS_URL);
+      expect(list.request.method).toBe('GET');
+      list.flush({
+        status: 200,
+        data: [
+          {
+            id: 'srv-1',
+            name: 'Cloud Comp',
+            description: 'desc',
+            symbol: 'CL',
+            numInputs: 1,
+            numOutputs: 1,
+            labels: ['a', 'q'],
+            createdOn: '2024-01-01',
+            lastEdited: '2024-01-01',
+            elementsFile: null,
+            previewDark: null,
+            previewLight: null,
+            public: false,
+            version: 2
+          }
+        ]
+      });
+
+      await promise;
+
+      const typeId = registry.masterTypeIdForId('srv-1');
+      expect(typeId).toBeDefined();
+      const def = registry.getDefinition(typeId!)!;
+      expect(def.source).toBe('server');
+      expect(def.name).toBe('Cloud Comp');
+      expect(def.numInputs).toBe(1);
+      expect(def.version).toBe(2);
+      // No circuit yet — it is fetched lazily on first placement / update.
+      expect(def.circuit).toBeUndefined();
+      // verify() in afterEach asserts no per-component GET was issued.
+    });
+
+    it('ensureServerMasterCircuit fetches and sets the circuit on demand', async () => {
+      const tick = () => new Promise((r) => setTimeout(r, 0));
+      const masterTypeId = registry.createMaster(
+        { id: 'srv-2', symbol: 'C', name: 'C' },
+        'server'
+      );
+      expect(registry.getDefinition(masterTypeId)?.circuit).toBeUndefined();
+
+      const promise = service.ensureServerMasterCircuit(masterTypeId);
+      await tick();
+      const open = httpMock.expectOne(COMPONENT_URL('srv-2'));
+      expect(open.request.method).toBe('GET');
+      open.flush({
+        status: 200,
+        data: {
+          id: 'srv-2',
+          name: 'C',
+          description: '',
+          symbol: 'C',
+          numInputs: 0,
+          numOutputs: 0,
+          labels: [],
+          createdOn: '2024-01-01',
+          lastEdited: '2024-01-01',
+          elementsFile: { hash: 'h', mimeType: 'application/json', publicUrl: '' },
+          previewDark: null,
+          previewLight: null,
+          public: false,
+          version: 1,
+          elements: [],
+          dependencies: []
+        }
+      });
+      await promise;
+
+      expect(registry.getDefinition(masterTypeId)?.circuit).toBeDefined();
+    });
+
+    it('ensureServerMasterCircuit is a no-op for a browser master (no fetch)', async () => {
+      const masterTypeId = registry.createMaster(
+        { id: 'local-x', symbol: 'X' },
+        'browser'
+      );
+      await service.ensureServerMasterCircuit(masterTypeId);
+      // verify() in afterEach asserts no HTTP request was made.
+    });
+
+    it('preloadServerMasters is a silent no-op when signed out (list 401s)', async () => {
+      const tick = () => new Promise((r) => setTimeout(r, 0));
+      const promise = service.preloadServerMasters();
+
+      await tick();
+      const list = httpMock.expectOne(COMPONENTS_URL);
+      list.flush(
+        { status: 401, data: null },
+        { status: 401, statusText: 'Unauthorized' }
+      );
+
+      await expect(promise).resolves.toBeUndefined();
+    });
 
     it('createServerComponent POSTs, PUTs an empty initial save, registers a server master', async () => {
       const promise = service.createServerComponent({

--- a/logigator-editor-v2/src/app/persistence/persistence.service.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.ts
@@ -22,7 +22,6 @@ import { ComponentProviderService } from '../components/component-provider.servi
 import { deriveSummary } from '../custom-component/definition-derivation';
 import { DefinitionBinding } from '../custom-component/definition-binding';
 import { buildProject, instantiateBody } from './circuit-builder';
-import { collectSnapshots } from './snapshots';
 import { formatHttpError } from './persistence-errors';
 import { ServerPersistenceGateway } from './server/server-persistence.gateway';
 import { downloadBlob } from '../utils/download';
@@ -476,6 +475,12 @@ export class PersistenceService {
     await Promise.all(
       summaries.map(async ({ id }) => {
         if (this.registry.masterTypeIdForId(id) !== undefined) return;
+        // A record whose id was promoted to the cloud is stale — its component
+        // moved to the server library. This guards the case where a previous
+        // promotion uploaded + aliased the component but failed to delete the
+        // local record; ignoring it here keeps a single (server) master. Relies
+        // on the alias map being hydrated first (see app startup ordering).
+        if (this.registry.isPromotedId(id)) return;
         try {
           const record = await this.browserComponentStore.get(id);
           if (!record) return;
@@ -568,29 +573,27 @@ export class PersistenceService {
     const record = await this.browserComponentStore.get(def.id);
     if (!record) return [];
 
-    const { components, wires } = this.circuitFile.fromJson(record.content);
-    const temp = buildProject(components, wires);
-    try {
-      const { definitions } = collectSnapshots(temp, this.registry);
-      const names = new Set<string>();
-      for (const dep of definitions) {
-        const masterId = dep.source?.id;
-        const resolvedMasterTypeId =
-          masterId !== undefined
-            ? this.registry.masterTypeIdForId(masterId)
-            : undefined;
-        const master =
-          resolvedMasterTypeId !== undefined
-            ? this.registry.getDefinition(resolvedMasterTypeId)
-            : undefined;
-        // Already in the cloud — its copy is fine, nothing local to mention.
-        if (master?.source === 'server') continue;
-        names.add(dep.name);
-      }
-      return [...names];
-    } finally {
-      temp.destroy();
+    // Read the embedded snapshot definitions straight from the stored file — the
+    // transitive closure is already baked in at save time — without building a
+    // live project or ingesting throwaway definitions into the registry. Each
+    // embedded custom whose provenance master is still browser-sourced (or can no
+    // longer be resolved) is a local component that rides along as a copy.
+    const names = new Set<string>();
+    for (const dep of this.circuitFile.peekDefinitions(record.content)) {
+      const masterId = dep.source?.id;
+      const resolvedMasterTypeId =
+        masterId !== undefined
+          ? this.registry.masterTypeIdForId(masterId)
+          : undefined;
+      const master =
+        resolvedMasterTypeId !== undefined
+          ? this.registry.getDefinition(resolvedMasterTypeId)
+          : undefined;
+      // Already in the cloud — its copy is fine, nothing local to mention.
+      if (master?.source === 'server') continue;
+      names.add(dep.name);
     }
+    return [...names];
   }
 
   /**
@@ -613,20 +616,73 @@ export class PersistenceService {
       throw new Error(`No browser component with id ${oldId}`);
     }
 
+    // Upload to the server first — the only irreversible, fail-able step. If it
+    // throws, nothing local has changed: the master is still browser-sourced, the
+    // record is intact and the upload button stays visible for a retry.
     const { components, wires } = this.circuitFile.fromJson(record.content);
     const temp = buildProject(components, wires);
+    let newId: string;
+    let version: number;
+    let newHash: string;
     try {
-      const { id: newId, version } =
-        await this.server.promoteComponentFromProject(temp, {
-          name: def.name,
-          symbol: def.symbol,
-          description: def.description
-        });
-      this.registry.promoteMaster(masterTypeId, newId, version);
-      await this.componentIdMapStore.put(oldId, newId);
-      await this.browserComponentStore.delete(oldId);
+      ({
+        id: newId,
+        version,
+        hash: newHash
+      } = await this.server.promoteComponentFromProject(temp, {
+        name: def.name,
+        symbol: def.symbol,
+        description: def.description
+      }));
     } finally {
       temp.destroy();
+    }
+
+    // The component now lives in the cloud — past the point of no return. Persist
+    // the durable old→new alias and drop the local record *before* the in-memory
+    // flip, so a reload stays consistent even if interrupted here. These local
+    // writes must not fail the operation: the upload already succeeded, so
+    // surfacing an error would be a lie (and would hide the now-disabled retry).
+    // A failure here self-heals on reload — the browser preload ignores a record
+    // whose id has been promoted (see preloadBrowserMasters / isPromotedId).
+    try {
+      await this.componentIdMapStore.put(oldId, newId);
+      await this.browserComponentStore.delete(oldId);
+    } catch {
+      this.logging.warn(
+        `Component ${oldId} uploaded to the cloud, but local cleanup failed`,
+        'PersistenceService'
+      );
+    }
+
+    this.registry.promoteMaster(masterTypeId, newId, version);
+    // If the master's own editor tab is open, flip its metadata to the new server
+    // identity so a later save routes to the cloud instead of re-creating the
+    // browser record that was just deleted.
+    this._reconcilePromotedEditor(oldId, newId, newHash);
+  }
+
+  /**
+   * After a master is promoted to the cloud, re-points an open editor tab for it
+   * (matched by the old browser id) to the new server identity, so closing/saving
+   * that editor routes to the server save path rather than resurrecting the
+   * deleted browser record. No-op when no such editor is open.
+   */
+  private _reconcilePromotedEditor(
+    oldId: string,
+    newId: string,
+    hash: string
+  ): void {
+    const handle = this.metadataStore.getHandleById(oldId);
+    if (
+      handle?.metadata.type === 'comp' &&
+      handle.metadata.source === 'browser'
+    ) {
+      this.metadataStore.update(handle.project, {
+        source: 'server',
+        id: newId,
+        hash
+      });
     }
   }
 

--- a/logigator-editor-v2/src/app/persistence/persistence.service.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.ts
@@ -568,6 +568,22 @@ export class PersistenceService {
    * Returns an empty list for a server master or one with no local dependencies.
    */
   async localDependencyNames(masterTypeId: number): Promise<string[]> {
+    return (await this.localDependencies(masterTypeId)).map((d) => d.name);
+  }
+
+  /**
+   * The **local** custom components a browser master embeds (transitively), each
+   * paired with its registry master type id when it is still a registered browser
+   * master — `null` when the dependency only survives as an embedded snapshot and
+   * can no longer be resolved to its own master. Only the resolvable ones can be
+   * promoted to the cloud as separate library entries; the rest always ride along
+   * as embedded copies. Server-sourced embeds are omitted (already in the cloud).
+   * Drives the upload-to-cloud dialog: its names warn the user, its ids feed an
+   * "upload with dependencies". Empty for a server master or one with no local deps.
+   */
+  async localDependencies(
+    masterTypeId: number
+  ): Promise<{ name: string; masterTypeId: number | null }[]> {
     const def = this.registry.getDefinition(masterTypeId);
     if (!def || def.kind !== 'master' || !def.id) return [];
     const record = await this.browserComponentStore.get(def.id);
@@ -578,7 +594,8 @@ export class PersistenceService {
     // live project or ingesting throwaway definitions into the registry. Each
     // embedded custom whose provenance master is still browser-sourced (or can no
     // longer be resolved) is a local component that rides along as a copy.
-    const names = new Set<string>();
+    const seen = new Set<string>();
+    const deps: { name: string; masterTypeId: number | null }[] = [];
     for (const dep of this.circuitFile.peekDefinitions(record.content)) {
       const masterId = dep.source?.id;
       const resolvedMasterTypeId =
@@ -591,9 +608,17 @@ export class PersistenceService {
           : undefined;
       // Already in the cloud — its copy is fine, nothing local to mention.
       if (master?.source === 'server') continue;
-      names.add(dep.name);
+      if (seen.has(dep.name)) continue;
+      seen.add(dep.name);
+      deps.push({
+        name: dep.name,
+        masterTypeId:
+          master?.source === 'browser' && resolvedMasterTypeId !== undefined
+            ? resolvedMasterTypeId
+            : null
+      });
     }
-    return [...names];
+    return deps;
   }
 
   /**
@@ -605,7 +630,10 @@ export class PersistenceService {
    * the tile's indicator just flips to "cloud". Rejects if the master is not a
    * local component or its stored record is missing.
    */
-  async promoteComponentToServer(masterTypeId: number): Promise<void> {
+  async promoteComponentToServer(
+    masterTypeId: number,
+    isPublic = false
+  ): Promise<void> {
     const def = this.registry.getDefinition(masterTypeId);
     if (!def || def.kind !== 'master' || def.source !== 'browser' || !def.id) {
       throw new Error('Not a local component');
@@ -632,7 +660,8 @@ export class PersistenceService {
       } = await this.server.promoteComponentFromProject(temp, {
         name: def.name,
         symbol: def.symbol,
-        description: def.description
+        description: def.description,
+        isPublic
       }));
     } finally {
       temp.destroy();

--- a/logigator-editor-v2/src/app/persistence/persistence.service.ts
+++ b/logigator-editor-v2/src/app/persistence/persistence.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { CircuitFileService } from './file/circuit-file.service';
 import { BrowserProjectStore } from './browser/browser-project.store';
 import { BrowserComponentStore } from './browser/browser-component.store';
+import { ComponentIdMapStore } from './browser/component-id-map.store';
 import {
   BrowserComponentSummary,
   BrowserProjectSummary
@@ -21,6 +22,7 @@ import { ComponentProviderService } from '../components/component-provider.servi
 import { deriveSummary } from '../custom-component/definition-derivation';
 import { DefinitionBinding } from '../custom-component/definition-binding';
 import { buildProject, instantiateBody } from './circuit-builder';
+import { collectSnapshots } from './snapshots';
 import { formatHttpError } from './persistence-errors';
 import { ServerPersistenceGateway } from './server/server-persistence.gateway';
 import { downloadBlob } from '../utils/download';
@@ -34,6 +36,7 @@ export class PersistenceService {
   private readonly circuitFile = inject(CircuitFileService);
   private readonly browserStore = inject(BrowserProjectStore);
   private readonly browserComponentStore = inject(BrowserComponentStore);
+  private readonly componentIdMapStore = inject(ComponentIdMapStore);
   private readonly registry = inject(CustomComponentRegistry);
   private readonly provider = inject(ComponentProviderService);
   private readonly metadataStore = inject(ProjectMetadataStore);
@@ -499,6 +502,132 @@ export class PersistenceService {
         }
       })
     );
+  }
+
+  /**
+   * Registers all of the signed-in user's cloud library masters into the registry
+   * at startup (so they appear in the palette and resolve through the promotion
+   * alias after a reload). Delegates to the server gateway; a no-op when signed
+   * out. Call once at startup, after {@link preloadComponentIdAliases}.
+   */
+  preloadServerMasters(): Promise<void> {
+    return this.server.preloadServerMasters();
+  }
+
+  /**
+   * Lazily hydrates a preloaded server master's circuit (GET `/api/component/:id`)
+   * the first time it is needed — placement or update-to-latest. No-op for a master
+   * that is not server-sourced or whose circuit is already loaded. Safe to call
+   * repeatedly; only the first call for a given master fetches.
+   */
+  async ensureServerMasterCircuit(masterTypeId: number): Promise<void> {
+    const def = this.registry.getDefinition(masterTypeId);
+    if (
+      !def ||
+      def.kind !== 'master' ||
+      def.source !== 'server' ||
+      !def.id ||
+      def.circuit
+    ) {
+      return;
+    }
+    const circuit = await this.server.loadComponentCircuit(def.id);
+    this.registry.setMasterCircuit(masterTypeId, circuit);
+  }
+
+  /**
+   * Hydrates the registry's promotion alias map from the persistent id-map so
+   * components that embedded a master before it was uploaded to the cloud still
+   * resolve it (its id changed on promotion). Call once at startup, alongside
+   * {@link preloadBrowserMasters}. Best-effort: failures are logged, not thrown.
+   */
+  async preloadComponentIdAliases(): Promise<void> {
+    try {
+      const mappings = await this.componentIdMapStore.list();
+      for (const { id, newId } of mappings) {
+        this.registry.registerIdAlias(id, newId);
+      }
+    } catch {
+      this.logging.warn(
+        'Failed to load component id aliases',
+        'PersistenceService'
+      );
+    }
+  }
+
+  /**
+   * Names of the **local** custom components a browser master embeds (transitively),
+   * for the upload-to-cloud confirmation. Built from the master's stored circuit:
+   * each embedded custom whose provenance master is still browser-sourced (or can
+   * no longer be resolved) is listed — those already in the cloud are omitted.
+   * Returns an empty list for a server master or one with no local dependencies.
+   */
+  async localDependencyNames(masterTypeId: number): Promise<string[]> {
+    const def = this.registry.getDefinition(masterTypeId);
+    if (!def || def.kind !== 'master' || !def.id) return [];
+    const record = await this.browserComponentStore.get(def.id);
+    if (!record) return [];
+
+    const { components, wires } = this.circuitFile.fromJson(record.content);
+    const temp = buildProject(components, wires);
+    try {
+      const { definitions } = collectSnapshots(temp, this.registry);
+      const names = new Set<string>();
+      for (const dep of definitions) {
+        const masterId = dep.source?.id;
+        const resolvedMasterTypeId =
+          masterId !== undefined
+            ? this.registry.masterTypeIdForId(masterId)
+            : undefined;
+        const master =
+          resolvedMasterTypeId !== undefined
+            ? this.registry.getDefinition(resolvedMasterTypeId)
+            : undefined;
+        // Already in the cloud — its copy is fine, nothing local to mention.
+        if (master?.source === 'server') continue;
+        names.add(dep.name);
+      }
+      return [...names];
+    } finally {
+      temp.destroy();
+    }
+  }
+
+  /**
+   * Uploads (moves) a **browser** master to the server library: creates the server
+   * record and pushes its circuit (embedding a self-contained copy of every custom
+   * it places), flips the registry to the new server id while keeping the old id
+   * as an alias, persists that alias, then removes the browser record. The master
+   * keeps its session type id, so placed instances and the palette tile survive —
+   * the tile's indicator just flips to "cloud". Rejects if the master is not a
+   * local component or its stored record is missing.
+   */
+  async promoteComponentToServer(masterTypeId: number): Promise<void> {
+    const def = this.registry.getDefinition(masterTypeId);
+    if (!def || def.kind !== 'master' || def.source !== 'browser' || !def.id) {
+      throw new Error('Not a local component');
+    }
+    const oldId = def.id;
+    const record = await this.browserComponentStore.get(oldId);
+    if (!record) {
+      throw new Error(`No browser component with id ${oldId}`);
+    }
+
+    const { components, wires } = this.circuitFile.fromJson(record.content);
+    const temp = buildProject(components, wires);
+    try {
+      const { id: newId, version } =
+        await this.server.promoteComponentFromProject(temp, {
+          name: def.name,
+          symbol: def.symbol,
+          description: def.description
+        });
+      this.registry.promoteMaster(masterTypeId, newId, version);
+      await this.componentIdMapStore.put(oldId, newId);
+      await this.browserComponentStore.delete(oldId);
+    } finally {
+      temp.destroy();
+    }
   }
 
   /**

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -17,6 +17,7 @@ import { CustomComponentRegistry } from '../../components/custom/custom-componen
 import { ComponentProviderService } from '../../components/component-provider.service';
 import { deriveSummary } from '../../custom-component/definition-derivation';
 import { buildProject } from '../circuit-builder';
+import type { SerializedCircuitBody } from '../serialized-circuit';
 import { AuthRequiredError, formatHttpError } from '../persistence-errors';
 import { BoardSnapshotService } from '../../rendering/board-snapshot.service';
 
@@ -311,6 +312,56 @@ export class ServerPersistenceGateway {
   }
 
   /**
+   * Promotes a browser master to the server library: POSTs `/api/component` to
+   * mint the record, then PUTs the given (temp) project's circuit — embedding a
+   * self-contained snapshot of every custom it places, exactly like a normal
+   * component save. Returns the new server id + save-time version. The caller owns
+   * flipping the registry/metadata and removing the browser record; this method is
+   * pure transport (no local state changes), so a failed POST/PUT leaves nothing
+   * to unwind.
+   */
+  async promoteComponentFromProject(
+    project: Project,
+    meta: {
+      name: string;
+      symbol: string;
+      description: string;
+      isPublic?: boolean;
+    }
+  ): Promise<{ id: string; version: number }> {
+    const response = await firstValueFrom(
+      this.componentApi.create({
+        name: meta.name,
+        symbol: meta.symbol,
+        description: meta.description,
+        public: meta.isPublic ? 'true' : 'false'
+      })
+    );
+
+    const summary = deriveSummary(project);
+    const { elements, dependencies } = server.serializeProject(
+      project,
+      this.registry,
+      this.provider
+    );
+    const saveResponse = await firstValueFrom(
+      this.componentApi.save(response.id, {
+        oldHash: response.elementsFile?.hash ?? '',
+        dependencies,
+        elements,
+        numInputs: summary.numInputs,
+        numOutputs: summary.numOutputs,
+        labels: summary.labels
+      })
+    );
+
+    return {
+      id: response.id,
+      version: saveResponse.version ?? response.version ?? 1
+    };
+  }
+
+  /**
    * Loads a **server** library master into a fresh editor Project (the universal
    * embedded-snapshot path: the response's `dependencies[].snapshot` are revived
    * by the `v0ToV1` migration, so no extra fetches). Registers the master,
@@ -356,6 +407,62 @@ export class ServerPersistenceGateway {
     });
 
     return { project, masterTypeId };
+  }
+
+  /**
+   * Registers every cloud (server) library master into the registry at startup so
+   * they show in the palette and resolve through the promotion alias map after a
+   * reload (the alias points at a server id that must be loaded to be useful).
+   *
+   * Uses only the list response (`GET /api/component`) — one request, no circuits.
+   * The summary carries everything a master needs except its circuit body, which
+   * is fetched lazily on first placement / update (see
+   * {@link PersistenceService.ensureServerMasterCircuit}). Best-effort: skips when
+   * unauthenticated/offline (the list call fails). Masters already known (loaded by
+   * an open project) are left alone.
+   */
+  async preloadServerMasters(): Promise<void> {
+    let summaries;
+    try {
+      summaries = await firstValueFrom(this.componentApi.list());
+    } catch {
+      // Not authenticated (401) or offline — no cloud library to preload.
+      return;
+    }
+
+    for (const summary of summaries) {
+      if (this.registry.masterTypeIdForId(summary.id) !== undefined) continue;
+      this.registry.createMaster(
+        {
+          id: summary.id,
+          version: summary.version ?? 1,
+          name: summary.name,
+          symbol: summary.symbol,
+          description: summary.description,
+          numInputs: summary.numInputs,
+          numOutputs: summary.numOutputs,
+          labels: summary.labels
+          // circuit omitted — loaded on demand by ensureServerMasterCircuit
+        },
+        'server'
+      );
+    }
+  }
+
+  /**
+   * Fetches a server component's circuit body (GET `/api/component/:id`) for lazy
+   * hydration of a summary-only master. Used the first time a preloaded cloud
+   * master is placed or updated.
+   */
+  async loadComponentCircuit(uuid: string): Promise<SerializedCircuitBody> {
+    const detail = await firstValueFrom(this.componentApi.open(uuid));
+    return this.circuitFile.decodeToBodyFromData(
+      server.toCircuitFileV0({
+        name: detail.name,
+        elements: detail.elements,
+        dependencies: detail.dependencies
+      })
+    );
   }
 
   async saveProject(project: Project): Promise<void> {

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -12,7 +12,12 @@ import { ToastService } from '../../logging/toast.service';
 import { LoggingService } from '../../logging/logging.service';
 import { Project } from '../../project/project';
 import { ProjectSummary } from '../../api/models/project';
+import type {
+  ComponentDetail,
+  ComponentSummary
+} from '../../api/models/component';
 import { Page } from '../../api/models/shared';
+import type { CircuitFileV0 } from '../file/circuit-file.types';
 import { CustomComponentRegistry } from '../../components/custom/custom-component-registry.service';
 import { ComponentProviderService } from '../../components/component-provider.service';
 import { deriveSummary } from '../../custom-component/definition-derivation';
@@ -276,22 +281,11 @@ export class ServerPersistenceGateway {
       isPublic: meta.isPublic ?? false
     });
 
-    const summary = deriveSummary(project);
-    const { elements, dependencies } = server.serializeProject(
-      project,
-      this.registry,
-      this.provider
-    );
     try {
-      const saveResponse = await firstValueFrom(
-        this.componentApi.save(response.id, {
-          oldHash: response.elementsFile?.hash ?? '',
-          dependencies,
-          elements,
-          numInputs: summary.numInputs,
-          numOutputs: summary.numOutputs,
-          labels: summary.labels
-        })
+      const saveResponse = await this._saveComponentCircuit(
+        response.id,
+        project,
+        response.elementsFile?.hash ?? ''
       );
       this.metadataStore.updateHash(
         project,
@@ -318,7 +312,8 @@ export class ServerPersistenceGateway {
    * component save. Returns the new server id + save-time version. The caller owns
    * flipping the registry/metadata and removing the browser record; this method is
    * pure transport (no local state changes), so a failed POST/PUT leaves nothing
-   * to unwind.
+   * to unwind. Returns the new server id, save-time version, and content hash (so
+   * the caller can re-point an open editor's metadata).
    */
   async promoteComponentFromProject(
     project: Project,
@@ -328,7 +323,7 @@ export class ServerPersistenceGateway {
       description: string;
       isPublic?: boolean;
     }
-  ): Promise<{ id: string; version: number }> {
+  ): Promise<{ id: string; version: number; hash: string }> {
     const response = await firstValueFrom(
       this.componentApi.create({
         name: meta.name,
@@ -338,26 +333,16 @@ export class ServerPersistenceGateway {
       })
     );
 
-    const summary = deriveSummary(project);
-    const { elements, dependencies } = server.serializeProject(
+    const saveResponse = await this._saveComponentCircuit(
+      response.id,
       project,
-      this.registry,
-      this.provider
-    );
-    const saveResponse = await firstValueFrom(
-      this.componentApi.save(response.id, {
-        oldHash: response.elementsFile?.hash ?? '',
-        dependencies,
-        elements,
-        numInputs: summary.numInputs,
-        numOutputs: summary.numOutputs,
-        labels: summary.labels
-      })
+      response.elementsFile?.hash ?? ''
     );
 
     return {
       id: response.id,
-      version: saveResponse.version ?? response.version ?? 1
+      version: saveResponse.version ?? response.version ?? 1,
+      hash: saveResponse.elementsFile?.hash ?? ''
     };
   }
 
@@ -373,11 +358,7 @@ export class ServerPersistenceGateway {
   ): Promise<{ project: Project; masterTypeId: number }> {
     const detail = await firstValueFrom(this.componentApi.open(uuid));
     const { components, wires } = this.circuitFile.decode(
-      server.toCircuitFileV0({
-        name: detail.name,
-        elements: detail.elements,
-        dependencies: detail.dependencies
-      })
+      this._componentDetailToV0(detail)
     );
     const project = buildProject(components, wires);
 
@@ -457,11 +438,7 @@ export class ServerPersistenceGateway {
   async loadComponentCircuit(uuid: string): Promise<SerializedCircuitBody> {
     const detail = await firstValueFrom(this.componentApi.open(uuid));
     return this.circuitFile.decodeToBodyFromData(
-      server.toCircuitFileV0({
-        name: detail.name,
-        elements: detail.elements,
-        dependencies: detail.dependencies
-      })
+      this._componentDetailToV0(detail)
     );
   }
 
@@ -524,23 +501,12 @@ export class ServerPersistenceGateway {
     const metadata = this.metadataStore.getMetadata(project)!;
     const masterTypeId = this.registry.masterTypeIdForId(metadata.id);
     const versionAtSnapshot = this.metadataStore.dirtyVersion(project);
-    const summary = deriveSummary(project);
-    const { elements, dependencies } = server.serializeProject(
-      project,
-      this.registry,
-      this.provider
-    );
 
     try {
-      const response = await firstValueFrom(
-        this.componentApi.save(metadata.id, {
-          oldHash: metadata.hash,
-          dependencies,
-          elements,
-          numInputs: summary.numInputs,
-          numOutputs: summary.numOutputs,
-          labels: summary.labels
-        })
+      const response = await this._saveComponentCircuit(
+        metadata.id,
+        project,
+        metadata.hash
       );
 
       this.metadataStore.updateHash(project, response.elementsFile?.hash ?? '');
@@ -573,13 +539,59 @@ export class ServerPersistenceGateway {
   }
 
   /**
+   * Serializes `project` and PUTs it to `/api/component/:id` — the shared
+   * create/save/promote tail: derive the summary, embed a self-contained snapshot
+   * of every custom it places, and push. Returns the save response (new hash +
+   * version). Pure transport; the caller owns metadata/registry/dirty handling.
+   */
+  private _saveComponentCircuit(
+    componentId: string,
+    project: Project,
+    oldHash: string
+  ): Promise<ComponentSummary> {
+    const summary = deriveSummary(project);
+    const { elements, dependencies } = server.serializeProject(
+      project,
+      this.registry,
+      this.provider
+    );
+    return firstValueFrom(
+      this.componentApi.save(componentId, {
+        oldHash,
+        dependencies,
+        elements,
+        numInputs: summary.numInputs,
+        numOutputs: summary.numOutputs,
+        labels: summary.labels
+      })
+    );
+  }
+
+  /**
+   * Wraps a component detail response as a {@link CircuitFileV0} envelope so it
+   * routes through the permanent `v0ToV1` migration — shared by the full load
+   * ({@link loadComponent}) and the lazy circuit hydration
+   * ({@link loadComponentCircuit}).
+   */
+  private _componentDetailToV0(detail: ComponentDetail): CircuitFileV0 {
+    return server.toCircuitFileV0({
+      name: detail.name,
+      elements: detail.elements,
+      dependencies: detail.dependencies
+    });
+  }
+
+  /**
    * Renders and uploads dark + light project thumbnails after a successful
    * server save. Fire-and-forget: a preview is a nice-to-have, so any failure
    * is logged and swallowed rather than surfaced or allowed to fail the save.
    * Order matters — the backend maps `previews[0]` to the dark slot and
    * `previews[1]` to the light slot.
    */
-  private async _uploadPreview(project: Project, projectId: string): Promise<void> {
+  private async _uploadPreview(
+    project: Project,
+    projectId: string
+  ): Promise<void> {
     try {
       const previews = await this.snapshot.generatePreviews(project);
       if (!previews) return;

--- a/logigator-editor-v2/src/app/storage/indexed-db-store.ts
+++ b/logigator-editor-v2/src/app/storage/indexed-db-store.ts
@@ -1,11 +1,17 @@
 const DB_NAME = 'logigator-editor';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const LAST_EDITED_INDEX = 'lastEdited';
 
 /** Object store holding saved projects (`StoredBrowserProject`). */
 export const PROJECTS_STORE = 'projects';
 /** Object store holding library masters (`StoredBrowserComponent`). */
 export const COMPONENTS_STORE = 'components';
+/**
+ * Object store mapping a master's old (pre-promotion) local id to the server id
+ * it was promoted to (`StoredComponentIdMapping`). Lets snapshots that captured
+ * the old id still resolve to the promoted master after an upload-to-cloud.
+ */
+export const COMPONENT_ID_MAP_STORE = 'componentIdMap';
 
 let dbPromise: Promise<IDBDatabase> | undefined;
 
@@ -24,7 +30,11 @@ function openDatabase(): Promise<IDBDatabase> {
       const request = indexedDB.open(DB_NAME, DB_VERSION);
       request.onupgradeneeded = () => {
         const db = request.result;
-        for (const name of [PROJECTS_STORE, COMPONENTS_STORE]) {
+        for (const name of [
+          PROJECTS_STORE,
+          COMPONENTS_STORE,
+          COMPONENT_ID_MAP_STORE
+        ]) {
           if (!db.objectStoreNames.contains(name)) {
             const store = db.createObjectStore(name, { keyPath: 'id' });
             store.createIndex(LAST_EDITED_INDEX, 'lastEdited');

--- a/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.html
+++ b/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.html
@@ -1,9 +1,31 @@
 @if (componentSettings(); as settings) {
   <p-card
     [class]="floating() ? 'absolute m-2 bottom-0 right-0 max-w-96' : 'block'"
-    [header]="text(settings.name)"
-    [subheader]="text(settings.description)"
   >
+    <ng-template #title>
+      <span class="flex items-center gap-2 flex-wrap">
+        <span>{{ text(settings.name) }}</span>
+        @if (settings.source; as source) {
+          <span
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-normal border"
+            [class]="
+              source === 'server'
+                ? 'text-sky-400 border-sky-400/40'
+                : 'text-muted border-border'
+            "
+            [title]="
+              source === 'server'
+                ? 'Saved in your cloud library'
+                : 'Saved in this browser only'
+            "
+          >
+            <i [class]="source === 'server' ? 'ph ph-cloud' : 'ph ph-browser'"></i>
+            {{ source === 'server' ? 'Cloud' : 'Local' }}
+          </span>
+        }
+      </span>
+    </ng-template>
+    <ng-template #subtitle>{{ text(settings.description) }}</ng-template>
     <form class="flex flex-col gap-2">
       @for (o of options(); track o.key) {
         <ng-container

--- a/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.html
+++ b/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.html
@@ -6,22 +6,7 @@
       <span class="flex items-center gap-2 flex-wrap">
         <span>{{ text(settings.name) }}</span>
         @if (settings.source; as source) {
-          <span
-            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-normal border"
-            [class]="
-              source === 'server'
-                ? 'text-sky-400 border-sky-400/40'
-                : 'text-muted border-border'
-            "
-            [title]="
-              source === 'server'
-                ? 'Saved in your cloud library'
-                : 'Saved in this browser only'
-            "
-          >
-            <i [class]="source === 'server' ? 'ph ph-cloud' : 'ph ph-browser'"></i>
-            {{ source === 'server' ? 'Cloud' : 'Local' }}
-          </span>
+          <app-source-indicator [source]="source" />
         }
       </span>
     </ng-template>

--- a/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.ts
+++ b/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.ts
@@ -17,6 +17,8 @@ import {
 } from '../../components/component-config.model';
 import { TranslocoService } from '@jsverse/transloco';
 import { ChangeOptionAction } from '../../actions/actions/change-option.action';
+import { CustomComponentRegistry } from '../../components/custom/custom-component-registry.service';
+import { CUSTOM_TYPE_ID_BASE } from '../../components/component-type.enum';
 
 @Component({
   selector: 'app-component-settings',
@@ -29,6 +31,7 @@ export class ComponentSettingsComponent {
   private readonly inspector = inject(SelectionInspectorService);
   private readonly projectService = inject(ProjectService);
   private readonly translocoService = inject(TranslocoService);
+  private readonly registry = inject(CustomComponentRegistry);
 
   /**
    * Desktop floats the card in the board's bottom-right corner; the mobile
@@ -61,7 +64,8 @@ export class ComponentSettingsComponent {
           ghost.options[key].value = value;
         },
         actions: [],
-        context: null
+        context: null,
+        source: this._customSource(ghost.type)
       };
     }
 
@@ -80,7 +84,8 @@ export class ComponentSettingsComponent {
           );
         },
         actions: selected.config.actions ?? [],
-        context: { component: selected, project }
+        context: { component: selected, project },
+        source: this._customSource(selected.config.type)
       };
     }
 
@@ -103,6 +108,18 @@ export class ComponentSettingsComponent {
         commit: (value: unknown) => settings.commit(key, value)
       }));
   });
+
+  /**
+   * The cloud/local library of a custom component (master or placed snapshot),
+   * resolved through its master so a placed instance reads the master's current
+   * source. `null` for built-ins. Reads the registry revision so the chip
+   * re-resolves after an upload-to-cloud flips the source.
+   */
+  private _customSource(typeId: number): 'server' | 'browser' | null {
+    this.registry.revision();
+    if (typeId < CUSTOM_TYPE_ID_BASE) return null;
+    return this.registry.resolveMaster(typeId)?.master.source ?? null;
+  }
 
   /** Resolves display text: translates a key, returns a literal verbatim. */
   protected text(value: LocalizableText): string {

--- a/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.ts
+++ b/logigator-editor-v2/src/app/ui/component-settings/component-settings.component.ts
@@ -19,10 +19,11 @@ import { TranslocoService } from '@jsverse/transloco';
 import { ChangeOptionAction } from '../../actions/actions/change-option.action';
 import { CustomComponentRegistry } from '../../components/custom/custom-component-registry.service';
 import { CUSTOM_TYPE_ID_BASE } from '../../components/component-type.enum';
+import { SourceIndicatorComponent } from '../source-indicator/source-indicator.component';
 
 @Component({
   selector: 'app-component-settings',
-  imports: [NgComponentOutlet, Card],
+  imports: [NgComponentOutlet, Card, SourceIndicatorComponent],
   templateUrl: './component-settings.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.html
+++ b/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.html
@@ -14,20 +14,7 @@
       >
         {{ comp.symbol }}
         @if (comp.source; as source) {
-          <span
-            class="absolute -top-1.5 -left-1.5 flex items-center justify-center w-4 h-4 rounded-full bg-content border border-border"
-            [title]="
-              source === 'server'
-                ? 'Saved in your cloud library'
-                : 'Saved in this browser only'
-            "
-          >
-            @if (source === 'server') {
-              <i class="ph ph-cloud text-sky-400 text-[0.6rem]"></i>
-            } @else {
-              <i class="ph ph-browser text-muted text-[0.6rem]"></i>
-            }
-          </span>
+          <app-source-indicator [source]="source" variant="badge" />
         }
         @if (selected) {
           <span

--- a/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.html
+++ b/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.html
@@ -13,6 +13,22 @@
         "
       >
         {{ comp.symbol }}
+        @if (comp.source; as source) {
+          <span
+            class="absolute -top-1.5 -left-1.5 flex items-center justify-center w-4 h-4 rounded-full bg-content border border-border"
+            [title]="
+              source === 'server'
+                ? 'Saved in your cloud library'
+                : 'Saved in this browser only'
+            "
+          >
+            @if (source === 'server') {
+              <i class="ph ph-cloud text-sky-400 text-[0.6rem]"></i>
+            } @else {
+              <i class="ph ph-browser text-muted text-[0.6rem]"></i>
+            }
+          </span>
+        }
         @if (selected) {
           <span
             class="absolute -top-1.5 -right-1.5 flex items-center justify-center w-4 h-4 rounded-full bg-primary text-surface-950"

--- a/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.spec.ts
+++ b/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.spec.ts
@@ -27,12 +27,13 @@ describe('ComponentListCategoryComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('arms placement and closes the open mobile sheet on selection', () => {
+  it('arms placement and closes the open mobile sheet on selection', async () => {
     const mobileUi = TestBed.inject(MobileUiService);
     const workMode = TestBed.inject(WorkModeService);
     mobileUi.open('palette');
 
-    component.selectComponent(andComponentConfig);
+    // selectComponent awaits a (no-op for built-ins) circuit-ensure before arming.
+    await component.selectComponent(andComponentConfig);
 
     expect(workMode.mode()).toBe(WorkMode.COMPONENT_PLACEMENT);
     expect(workMode.selectedComponentType()).toBe(andComponentConfig.type);

--- a/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.ts
+++ b/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.ts
@@ -15,10 +15,11 @@ import { WorkModeService } from '../../../work-mode/work-mode.service';
 import { WorkMode } from '../../../work-mode/work-mode.enum';
 import { MobileUiService } from '../../../layout/mobile-ui.service';
 import { CustomComponentService } from '../../../custom-component/custom-component.service';
+import { SourceIndicatorComponent } from '../../source-indicator/source-indicator.component';
 
 @Component({
   selector: 'app-component-list-category',
-  imports: [],
+  imports: [SourceIndicatorComponent],
   templateUrl: './component-list-category.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -54,8 +55,14 @@ export class ComponentListCategoryComponent {
   /** Arms the component for placement (sticky until another tool is chosen). */
   public async selectComponent(component: ComponentConfig): Promise<void> {
     // Cloud masters are preloaded summary-only; fetch the circuit before arming so
-    // the placement snapshot has real content. No-op for built-ins / loaded masters.
-    await this.customComponentService.ensureMasterCircuit(component.type);
+    // the placement snapshot has real content. No-op for built-ins / loaded
+    // masters; bail (the service has already toasted) if the cloud fetch fails so
+    // we never arm placement against empty content.
+    if (
+      !(await this.customComponentService.ensureMasterCircuit(component.type))
+    ) {
+      return;
+    }
     this.workModeService.setMode(WorkMode.COMPONENT_PLACEMENT);
     this.workModeService.setSelectedComponentType(component.type);
     // On mobile the palette is a sheet; picking from it dismisses it so the

--- a/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.ts
+++ b/logigator-editor-v2/src/app/ui/side-bar/component-list-category/component-list-category.component.ts
@@ -14,6 +14,7 @@ import { TranslocoService } from '@jsverse/transloco';
 import { WorkModeService } from '../../../work-mode/work-mode.service';
 import { WorkMode } from '../../../work-mode/work-mode.enum';
 import { MobileUiService } from '../../../layout/mobile-ui.service';
+import { CustomComponentService } from '../../../custom-component/custom-component.service';
 
 @Component({
   selector: 'app-component-list-category',
@@ -25,6 +26,7 @@ export class ComponentListCategoryComponent {
   private readonly workModeService = inject(WorkModeService);
   private readonly translocoService = inject(TranslocoService);
   private readonly mobileUi = inject(MobileUiService);
+  private readonly customComponentService = inject(CustomComponentService);
 
   /** The palette tiles to render; already filtered by the parent's search. */
   public components = input<ComponentConfig[]>([]);
@@ -50,7 +52,10 @@ export class ComponentListCategoryComponent {
   });
 
   /** Arms the component for placement (sticky until another tool is chosen). */
-  public selectComponent(component: ComponentConfig): void {
+  public async selectComponent(component: ComponentConfig): Promise<void> {
+    // Cloud masters are preloaded summary-only; fetch the circuit before arming so
+    // the placement snapshot has real content. No-op for built-ins / loaded masters.
+    await this.customComponentService.ensureMasterCircuit(component.type);
     this.workModeService.setMode(WorkMode.COMPONENT_PLACEMENT);
     this.workModeService.setSelectedComponentType(component.type);
     // On mobile the palette is a sheet; picking from it dismisses it so the

--- a/logigator-editor-v2/src/app/ui/source-indicator/source-indicator.component.ts
+++ b/logigator-editor-v2/src/app/ui/source-indicator/source-indicator.component.ts
@@ -1,0 +1,61 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input
+} from '@angular/core';
+
+/**
+ * Cloud/local provenance indicator for a custom component, in two variants:
+ *
+ * - `chip` (default) — a pill with an icon + "Cloud"/"Local" label, shown in the
+ *   component-settings header.
+ * - `badge` — a small corner glyph, overlaid on a palette tile (the tile is the
+ *   positioned ancestor; the host is `display: contents` so the absolute badge
+ *   anchors to the tile exactly as the inline markup did).
+ *
+ * Owns the icon, colour and tooltip wording so both call sites stay in sync.
+ */
+@Component({
+  selector: 'app-source-indicator',
+  host: { class: 'contents' },
+  template: `@if (variant() === 'badge') {
+      <span
+        class="absolute -top-1.5 -left-1.5 flex items-center justify-center w-4 h-4 rounded-full bg-content border border-border"
+        [title]="title()"
+      >
+        @if (isServer()) {
+          <i class="ph ph-cloud text-sky-400 text-[0.6rem]"></i>
+        } @else {
+          <i class="ph ph-browser text-muted text-[0.6rem]"></i>
+        }
+      </span>
+    } @else {
+      <span
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-normal border"
+        [class]="
+          isServer()
+            ? 'text-sky-400 border-sky-400/40'
+            : 'text-muted border-border'
+        "
+        [title]="title()"
+      >
+        <i [class]="isServer() ? 'ph ph-cloud' : 'ph ph-browser'"></i>
+        {{ isServer() ? 'Cloud' : 'Local' }}
+      </span>
+    }`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SourceIndicatorComponent {
+  /** Which library the component lives in. */
+  public readonly source = input.required<'server' | 'browser'>();
+  /** Visual form: a labelled pill (`chip`) or a tile corner glyph (`badge`). */
+  public readonly variant = input<'chip' | 'badge'>('chip');
+
+  protected readonly isServer = computed(() => this.source() === 'server');
+  protected readonly title = computed(() =>
+    this.isServer()
+      ? 'Saved in your cloud library'
+      : 'Saved in this browser only'
+  );
+}

--- a/logigator-editor-v2/src/app/ui/upload-component-dialog/upload-component-dialog.component.html
+++ b/logigator-editor-v2/src/app/ui/upload-component-dialog/upload-component-dialog.component.html
@@ -1,0 +1,58 @@
+<div *transloco="let t" class="flex flex-col gap-4">
+  <p>{{ t('uploadComponent.intro', { name: name }) }}</p>
+
+  @if (dependencies().length) {
+    <div class="flex flex-col gap-1">
+      <span>{{ t('uploadComponent.depsTitle') }}</span>
+      <ul class="m-0 flex list-disc flex-col gap-1 pl-5">
+        @for (dep of dependencies(); track dep.name) {
+          <li>{{ dep.name }}</li>
+        }
+      </ul>
+    </div>
+  }
+
+  @if (userService.user()) {
+    <div class="flex gap-2 items-center">
+      <p-toggleswitch
+        inputId="upload-component-public"
+        [ngModel]="isPublic()"
+        (ngModelChange)="isPublic.set($event)"
+        [ngModelOptions]="{ standalone: true }"
+      />
+      <label for="upload-component-public">{{
+        t('uploadComponent.public')
+      }}</label>
+      <i
+        class="ph ph-info cursor-help text-surface-500"
+        [pTooltip]="t('uploadComponent.publicInfo')"
+      ></i>
+    </div>
+  } @else {
+    <app-message severity="warn">
+      {{ t('uploadComponent.notLoggedIn') }}
+    </app-message>
+  }
+
+  <div class="flex justify-end gap-2">
+    <p-button
+      severity="secondary"
+      [outlined]="true"
+      [label]="t('uploadComponent.cancel')"
+      (onClick)="cancel()"
+    />
+    <p-button
+      [label]="t('uploadComponent.upload')"
+      [disabled]="!userService.user()"
+      (onClick)="upload()"
+    />
+    @if (uploadableDependencies().length) {
+      <p-button
+        icon="ph ph-stack"
+        [label]="t('uploadComponent.uploadWithDeps')"
+        [disabled]="!userService.user()"
+        (onClick)="uploadWithDependencies($event)"
+      />
+    }
+  </div>
+</div>

--- a/logigator-editor-v2/src/app/ui/upload-component-dialog/upload-component-dialog.component.ts
+++ b/logigator-editor-v2/src/app/ui/upload-component-dialog/upload-component-dialog.component.ts
@@ -1,0 +1,112 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
+import { TooltipModule } from 'primeng/tooltip';
+import { Button } from 'primeng/button';
+import { ConfirmationService } from 'primeng/api';
+import { TranslocoDirective, TranslocoService } from '@jsverse/transloco';
+import { CustomComponentService } from '../../custom-component/custom-component.service';
+import { UserService } from '../../user/user.service';
+import { MessageComponent } from '../message/message.component';
+
+export interface UploadComponentDialogData {
+  masterTypeId: number;
+  name: string;
+}
+
+export interface UploadComponentDialogResult {
+  isPublic: boolean;
+  /** Whether to also upload the resolvable local dependencies as separate entries. */
+  withDependencies: boolean;
+}
+
+/**
+ * Collects the options for uploading a local custom component to the cloud:
+ * visibility (public/private) and, when the component embeds resolvable local
+ * dependencies, whether to upload those as separate cloud entries too. Collects
+ * input only — it closes with an {@link UploadComponentDialogResult} (or
+ * `undefined` when cancelled); {@link CustomComponentService} performs the upload.
+ * Visibility defaults to private to avoid surprise-publishing a previously-local
+ * component.
+ */
+@Component({
+  selector: 'app-upload-component-dialog',
+  imports: [
+    FormsModule,
+    ToggleSwitchModule,
+    TooltipModule,
+    Button,
+    TranslocoDirective,
+    MessageComponent
+  ],
+  templateUrl: './upload-component-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class UploadComponentDialogComponent {
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly config = inject(DynamicDialogConfig);
+  private readonly customComponentService = inject(CustomComponentService);
+  private readonly confirmation = inject(ConfirmationService);
+  private readonly transloco = inject(TranslocoService);
+  protected readonly userService = inject(UserService);
+
+  private readonly data = this.config.data as
+    | UploadComponentDialogData
+    | undefined;
+
+  protected readonly name = this.data?.name ?? '';
+  protected readonly isPublic = signal(false);
+  protected readonly dependencies = signal<
+    { name: string; masterTypeId: number | null }[]
+  >([]);
+
+  /** Local dependencies that can be uploaded as their own cloud entries. */
+  protected readonly uploadableDependencies = computed(() =>
+    this.dependencies().filter((d) => d.masterTypeId !== null)
+  );
+
+  constructor() {
+    const masterTypeId = this.data?.masterTypeId;
+    if (masterTypeId !== undefined) {
+      void this.customComponentService
+        .localDependencies(masterTypeId)
+        .then((deps) => this.dependencies.set(deps));
+    }
+  }
+
+  protected cancel(): void {
+    this.ref.close();
+  }
+
+  protected upload(): void {
+    this.ref.close({
+      isPublic: this.isPublic(),
+      withDependencies: false
+    } satisfies UploadComponentDialogResult);
+  }
+
+  protected uploadWithDependencies(event: Event): void {
+    this.confirmation.confirm({
+      key: 'inline',
+      target: event.currentTarget as HTMLElement,
+      message: this.transloco.translate('uploadComponent.withDepsConfirm', {
+        count: this.uploadableDependencies().length
+      }),
+      acceptLabel: this.transloco.translate('uploadComponent.withDepsAccept'),
+      rejectLabel: this.transloco.translate('uploadComponent.withDepsReject'),
+      rejectButtonProps: { severity: 'secondary', outlined: true },
+      accept: () =>
+        this.ref.close({
+          isPublic: this.isPublic(),
+          withDependencies: true
+        } satisfies UploadComponentDialogResult)
+    });
+  }
+}

--- a/logigator-editor-v2/src/i18n/en.ts
+++ b/logigator-editor-v2/src/i18n/en.ts
@@ -253,6 +253,31 @@ const en = {
       'Browser components are not persisted across devices and may be lost.',
     create: 'Create'
   },
+  uploadComponent: {
+    button: 'Upload to cloud',
+    signInTooltip: 'Sign in to upload to the cloud',
+    dialogHeader: 'Upload to cloud',
+    intro:
+      '“{{name}}” is moved out of your local library and stored on your account.',
+    depsTitle:
+      'It embeds these local components as copies, which stay in your local library:',
+    public: 'Public',
+    publicInfo:
+      'Public components are published on your profile and accessible to everyone via a share link. Private components are only visible to you.',
+    notLoggedIn: 'You must be logged in to upload components to your account.',
+    cancel: 'Cancel',
+    upload: 'Upload',
+    uploadWithDeps: 'Upload with dependencies',
+    withDepsConfirm:
+      'This also uploads {{count}} local component(s) to your account with the same visibility. They become separate cloud components. Continue?',
+    withDepsAccept: 'Upload all',
+    withDepsReject: 'Cancel',
+    signInRequired: 'Sign in to upload components to the cloud',
+    success: 'Component uploaded to the cloud',
+    failure: 'Failed to upload component',
+    partialFailure:
+      'Component uploaded, but {{failed}} of {{total}} dependencies failed'
+  },
   toolBar: {
     save: 'Save',
     open: 'Open',

--- a/logigator-editor-v2/src/testing/fake-browser-stores.ts
+++ b/logigator-editor-v2/src/testing/fake-browser-stores.ts
@@ -47,6 +47,23 @@ export class FakeBrowserProjectStore {
   }
 }
 
+/** In-memory stand-in for {@link ComponentIdMapStore} (which uses IndexedDB). */
+export class FakeComponentIdMapStore {
+  readonly records = new Map<string, string>();
+
+  async put(oldId: string, newId: string): Promise<void> {
+    this.records.set(oldId, newId);
+  }
+
+  async list(): Promise<{ id: string; newId: string; lastEdited: number }[]> {
+    return [...this.records.entries()].map(([id, newId]) => ({
+      id,
+      newId,
+      lastEdited: 0
+    }));
+  }
+}
+
 /** In-memory stand-in for {@link BrowserComponentStore} (which uses IndexedDB). */
 export class FakeBrowserComponentStore {
   readonly records = new Map<string, StoredBrowserComponent>();


### PR DESCRIPTION
This pull request introduces a comprehensive set of changes to support promoting custom components from the local ("browser") library to the cloud ("server") library, with robust handling of ID aliasing, dependency tracking, and UI integration. Key improvements include tracking component source, resolving pre-promotion IDs, updating dependencies after circuit changes, and adding a UI action to upload components to the cloud.

**Custom Component Promotion & ID Aliasing**

* Added an ID alias map and related methods in `CustomComponentRegistry` to support resolving old (pre-promotion) IDs to current master components, ensuring that snapshots and other references remain valid after a component is uploaded to the cloud. Includes methods for registering aliases, checking promotion status, and resolving masters through aliases. [[1]](diffhunk://#diff-713396aa1a6c3799d19f3c6b8ca46181943f95dbf6c0e877a4da00f88cc5c04fR48-R52) [[2]](diffhunk://#diff-713396aa1a6c3799d19f3c6b8ca46181943f95dbf6c0e877a4da00f88cc5c04fL250-R364)
* Implemented the `promoteMaster` method to update a component's source, ID, and version upon promotion, maintain both old and new IDs, update the palette, and bump a revision signal for reactive UI updates.

**Dependency Tracking Improvements**

* Updated `setMasterCircuit` and added `_recomputeDependencies` to ensure that dependency graphs are correctly updated whenever a master's circuit changes—including after lazy cloud hydration—so cycle detection remains accurate. [[1]](diffhunk://#diff-713396aa1a6c3799d19f3c6b8ca46181943f95dbf6c0e877a4da00f88cc5c04fL217-R234) [[2]](diffhunk://#diff-713396aa1a6c3799d19f3c6b8ca46181943f95dbf6c0e877a4da00f88cc5c04fR244-R264)
* Added tests to verify that dependencies are recomputed and that ID aliasing and promotion logic work as intended. [[1]](diffhunk://#diff-73046214a3ba47d461b42bf549bc4b9370ce01137916415f2109cb5eb49380ccR350-R371) [[2]](diffhunk://#diff-73046214a3ba47d461b42bf549bc4b9370ce01137916415f2109cb5eb49380ccR473-R576)

**UI & Inspector Integration**

* Added a new inspector action, `UploadComponentAction`, and its renderer component, which displays a button to upload (promote) a local custom component to the cloud. The button is only visible for local components and is disabled when the user is not signed in. [[1]](diffhunk://#diff-4f75f49633600a2350b0a34bd6dc3e7e6bbec75b4826a68bfaa4e1ddde8b0addR1-R8) [[2]](diffhunk://#diff-8d005b89dc38703936ca26b0b7bfcb37ceaa7a7277772bd281fd70b55c7e2a14R1-R64)
* Updated the custom component config to expose the `source` property and include the new upload action, allowing the UI to reactively display the component's current library (cloud/local) and provide upload functionality. [[1]](diffhunk://#diff-23ff7303b901f0ab843c3f1e1df1ee93bccb7f27f3e53b1dec709dcae1699d24R63-R68) [[2]](diffhunk://#diff-edd9d621c8160c7e268b15d77e9abd315390f4c09ac90d2d697767a2741b7551R47-R51) [[3]](diffhunk://#diff-edd9d621c8160c7e268b15d77e9abd315390f4c09ac90d2d697767a2741b7551R9) [[4]](diffhunk://#diff-edd9d621c8160c7e268b15d77e9abd315390f4c09ac90d2d697767a2741b7551L60-R70)

**App Initialization & Preloading**

* Modified app initialization to preload component ID aliases and server masters before loading browser masters, ensuring that all alias mappings are in place for correct component resolution and to avoid loading stale local records. [[1]](diffhunk://#diff-3c998ed797a91d1e4cbee9b4f581a975ac8f9d43a020dd5813c3d9a27242a6c6L141-R151) [[2]](diffhunk://#diff-d67a9929f3ac59077f2dd8333f59b111f3ea82c6bd36ccee03fc7d8abfc71507R50-R51)

**Other Enhancements**

* Made the update of custom component instances asynchronous to ensure that cloud masters are fully hydrated before updating, preventing errors when summary-only preloads are present.

These changes collectively ensure that custom components can be safely promoted to the cloud, with all references and dependencies remaining consistent and the UI accurately reflecting the current state.