### PR TITLE
Feat/server snapshots

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,9 @@ Three independent packages using **Yarn 4** (corepack) — no workspace manager:
 - `logigator-editor/` — Legacy Angular 17 editor (PixiJS 7), being replaced
 - `logigator-editor-v2/` — Angular 21 editor (PixiJS 8, Tailwind 4, PrimeNG), current focus
 
-All commands run inside Docker containers. Do not run yarn directly on the host.
-
 ## Dev Environment
 
 Backend config files must be created from `.example` files in `logigator-backend/config/`.
-
-Service names for exec: `editor` (logigator-editor-v2), `editor-old` (logigator-editor), `backend` (logigator-backend).
 
 ## Commands
 

--- a/logigator-backend/migration/1719662400000-AddNewFormatFlag.ts
+++ b/logigator-backend/migration/1719662400000-AddNewFormatFlag.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddNewFormatFlag1719662400000 implements MigrationInterface {
+    name = 'AddNewFormatFlag1719662400000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("ALTER TABLE `project` ADD `newFormat` tinyint NOT NULL DEFAULT 0");
+        await queryRunner.query("ALTER TABLE `component` ADD `newFormat` tinyint NOT NULL DEFAULT 0");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("ALTER TABLE `component` DROP COLUMN `newFormat`");
+        await queryRunner.query("ALTER TABLE `project` DROP COLUMN `newFormat`");
+    }
+
+}

--- a/logigator-backend/src/controller/api/component.controller.ts
+++ b/logigator-backend/src/controller/api/component.controller.ts
@@ -22,7 +22,7 @@ import {User} from '../../database/entities/user.entity';
 import {InjectRepository} from 'typeorm-typedi-extensions';
 import {ComponentRepository} from '../../database/repositories/component.repository';
 import {CreateComponent} from '../../models/request/shared/create-component';
-import {buildDependencyResponse, isLegacyFormat, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
+import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {classToPlain} from 'class-transformer';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {ComponentFile} from '../../database/entities/component-file.entity';
@@ -83,7 +83,7 @@ export class ComponentController {
 			...classToPlain(component),
 			dependencies: buildDependencyResponse(dependencies, enriched),
 			elements,
-			legacyFormat: isLegacyFormat(elements, snapshots)
+			legacyFormat: !component.newFormat
 		};
 	}
 
@@ -101,6 +101,7 @@ export class ComponentController {
 			component.elementsFile = new ComponentFile();
 
 		component.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies, previous.snapshots));
+		component.newFormat = body.newFormat ?? false;
 		component.numInputs = body.numInputs;
 		component.numOutputs = body.numOutputs;
 		component.labels = body.labels;

--- a/logigator-backend/src/controller/api/component.controller.ts
+++ b/logigator-backend/src/controller/api/component.controller.ts
@@ -22,7 +22,7 @@ import {User} from '../../database/entities/user.entity';
 import {InjectRepository} from 'typeorm-typedi-extensions';
 import {ComponentRepository} from '../../database/repositories/component.repository';
 import {CreateComponent} from '../../models/request/shared/create-component';
-import {ProjectElement} from '../../models/request/api/project-element';
+import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit} from '../../functions/circuit-content';
 import {classToPlain} from 'class-transformer';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {ComponentFile} from '../../database/entities/component-file.entity';
@@ -76,12 +76,12 @@ export class ComponentController {
 		});
 
 		const contentBuffer = await component.elementsFile?.getFileContent();
-		const content: ProjectElement[] = contentBuffer?.length ? JSON.parse(contentBuffer.toString()) : [];
+		const {elements, snapshots} = parseStoredCircuit(contentBuffer);
 
 		return {
 			...classToPlain(component),
-			dependencies,
-			elements: content ?? []
+			dependencies: buildDependencyResponse(dependencies, snapshots),
+			elements
 		};
 	}
 
@@ -96,7 +96,7 @@ export class ComponentController {
 		if (!component.elementsFile)
 			component.elementsFile = new ComponentFile();
 
-		component.elementsFile.setFileContent(JSON.stringify(body.elements));
+		component.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies));
 		component.numInputs = body.numInputs;
 		component.numOutputs = body.numOutputs;
 		component.labels = body.labels;
@@ -105,6 +105,10 @@ export class ComponentController {
 		const deps = [];
 		const depSet = new Set<string>();
 		for (const mapping of body.dependencies) {
+			// Local-only customs (never uploaded to the library) carry no master
+			// id — they live solely in the embedded snapshot, so create no row.
+			if (!mapping.id)
+				continue;
 			const depComp = await this.componentRepo.getOwnedComponentOrThrow(mapping.id, user, `Component for mapping '${mapping.id}' not found.`);
 			const dep = this.componentDepRepo.create();
 			dep.dependency = depComp;

--- a/logigator-backend/src/controller/api/component.controller.ts
+++ b/logigator-backend/src/controller/api/component.controller.ts
@@ -22,7 +22,7 @@ import {User} from '../../database/entities/user.entity';
 import {InjectRepository} from 'typeorm-typedi-extensions';
 import {ComponentRepository} from '../../database/repositories/component.repository';
 import {CreateComponent} from '../../models/request/shared/create-component';
-import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit} from '../../functions/circuit-content';
+import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {classToPlain} from 'class-transformer';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {ComponentFile} from '../../database/entities/component-file.entity';
@@ -77,10 +77,11 @@ export class ComponentController {
 
 		const contentBuffer = await component.elementsFile?.getFileContent();
 		const {elements, snapshots} = parseStoredCircuit(contentBuffer);
+		const enriched = await synthesizeMissingSnapshots(dependencies, snapshots);
 
 		return {
 			...classToPlain(component),
-			dependencies: buildDependencyResponse(dependencies, snapshots),
+			dependencies: buildDependencyResponse(dependencies, enriched),
 			elements
 		};
 	}
@@ -93,10 +94,12 @@ export class ComponentController {
 		if (component.elementsFile && component.elementsFile.hash !== body.oldHash)
 			throw new BadRequestError('VersionMismatch');
 
+		const previous = parseStoredCircuit(await component.elementsFile?.getFileContent());
+
 		if (!component.elementsFile)
 			component.elementsFile = new ComponentFile();
 
-		component.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies));
+		component.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies, previous.snapshots));
 		component.numInputs = body.numInputs;
 		component.numOutputs = body.numOutputs;
 		component.labels = body.labels;

--- a/logigator-backend/src/controller/api/component.controller.ts
+++ b/logigator-backend/src/controller/api/component.controller.ts
@@ -83,7 +83,7 @@ export class ComponentController {
 			...classToPlain(component),
 			dependencies: buildDependencyResponse(dependencies, enriched),
 			elements,
-			legacyFormat: !component.newFormat
+			newFormat: component.newFormat
 		};
 	}
 

--- a/logigator-backend/src/controller/api/component.controller.ts
+++ b/logigator-backend/src/controller/api/component.controller.ts
@@ -22,7 +22,7 @@ import {User} from '../../database/entities/user.entity';
 import {InjectRepository} from 'typeorm-typedi-extensions';
 import {ComponentRepository} from '../../database/repositories/component.repository';
 import {CreateComponent} from '../../models/request/shared/create-component';
-import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
+import {buildDependencyResponse, isLegacyFormat, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {classToPlain} from 'class-transformer';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {ComponentFile} from '../../database/entities/component-file.entity';
@@ -82,7 +82,8 @@ export class ComponentController {
 		return {
 			...classToPlain(component),
 			dependencies: buildDependencyResponse(dependencies, enriched),
-			elements
+			elements,
+			legacyFormat: isLegacyFormat(elements, snapshots)
 		};
 	}
 

--- a/logigator-backend/src/controller/api/project.controller.ts
+++ b/logigator-backend/src/controller/api/project.controller.ts
@@ -28,7 +28,7 @@ import {UpdateProject} from '../../models/request/api/project/update-project';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
 import {ComponentRepository} from '../../database/repositories/component.repository';
-import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit} from '../../functions/circuit-content';
+import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {v4 as uuid} from 'uuid';
 import {getUploadedFileOptions} from '../../functions/get-uploaded-file-options';
 import {ProjectPreviewDark} from '../../database/entities/project-preview-dark.entity';
@@ -73,10 +73,11 @@ export class ProjectController {
 
 		const contentBuffer = await project.elementsFile?.getFileContent();
 		const {elements, snapshots} = parseStoredCircuit(contentBuffer);
+		const enriched = await synthesizeMissingSnapshots(dependencies, snapshots);
 
 		return {
 			...classToPlain(project, {groups: ['showShareLinks']}),
-			dependencies: buildDependencyResponse(dependencies, snapshots),
+			dependencies: buildDependencyResponse(dependencies, enriched),
 			elements
 		};
 	}
@@ -89,10 +90,12 @@ export class ProjectController {
 		if (project.elementsFile && project.elementsFile.hash !== body.oldHash)
 			throw new BadRequestError('VersionMismatch');
 
+		const previous = parseStoredCircuit(await project.elementsFile?.getFileContent());
+
 		if (!project.elementsFile)
 			project.elementsFile = new ProjectFile();
 
-		project.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies));
+		project.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies, previous.snapshots));
 		project.lastEdited = new Date();
 
 		const deps = [];

--- a/logigator-backend/src/controller/api/project.controller.ts
+++ b/logigator-backend/src/controller/api/project.controller.ts
@@ -28,7 +28,7 @@ import {UpdateProject} from '../../models/request/api/project/update-project';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
 import {ComponentRepository} from '../../database/repositories/component.repository';
-import {ProjectElement} from '../../models/request/api/project-element';
+import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit} from '../../functions/circuit-content';
 import {v4 as uuid} from 'uuid';
 import {getUploadedFileOptions} from '../../functions/get-uploaded-file-options';
 import {ProjectPreviewDark} from '../../database/entities/project-preview-dark.entity';
@@ -72,12 +72,12 @@ export class ProjectController {
 		});
 
 		const contentBuffer = await project.elementsFile?.getFileContent();
-		const content: ProjectElement[] = contentBuffer?.length ? JSON.parse(contentBuffer.toString()) : [];
+		const {elements, snapshots} = parseStoredCircuit(contentBuffer);
 
 		return {
 			...classToPlain(project, {groups: ['showShareLinks']}),
-			dependencies,
-			elements: content ?? []
+			dependencies: buildDependencyResponse(dependencies, snapshots),
+			elements
 		};
 	}
 
@@ -92,12 +92,16 @@ export class ProjectController {
 		if (!project.elementsFile)
 			project.elementsFile = new ProjectFile();
 
-		project.elementsFile.setFileContent(JSON.stringify(body.elements));
+		project.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies));
 		project.lastEdited = new Date();
 
 		const deps = [];
 		const depSet = new Set<string>();
 		for (const mapping of body.dependencies) {
+			// Local-only customs (never uploaded to the library) carry no master
+			// id — they live solely in the embedded snapshot, so create no row.
+			if (!mapping.id)
+				continue;
 			const depComp = await this.componentRepo.getOwnedComponentOrThrow(mapping.id, user, `Component for mapping '${mapping.id}' not found.`);
 			const dep = this.projectDepRepo.create();
 			dep.dependency = depComp;

--- a/logigator-backend/src/controller/api/project.controller.ts
+++ b/logigator-backend/src/controller/api/project.controller.ts
@@ -28,7 +28,7 @@ import {UpdateProject} from '../../models/request/api/project/update-project';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
 import {ComponentRepository} from '../../database/repositories/component.repository';
-import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
+import {buildDependencyResponse, isLegacyFormat, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {v4 as uuid} from 'uuid';
 import {getUploadedFileOptions} from '../../functions/get-uploaded-file-options';
 import {ProjectPreviewDark} from '../../database/entities/project-preview-dark.entity';
@@ -78,7 +78,8 @@ export class ProjectController {
 		return {
 			...classToPlain(project, {groups: ['showShareLinks']}),
 			dependencies: buildDependencyResponse(dependencies, enriched),
-			elements
+			elements,
+			legacyFormat: isLegacyFormat(elements, snapshots)
 		};
 	}
 

--- a/logigator-backend/src/controller/api/project.controller.ts
+++ b/logigator-backend/src/controller/api/project.controller.ts
@@ -79,7 +79,7 @@ export class ProjectController {
 			...classToPlain(project, {groups: ['showShareLinks']}),
 			dependencies: buildDependencyResponse(dependencies, enriched),
 			elements,
-			legacyFormat: !project.newFormat
+			newFormat: project.newFormat
 		};
 	}
 

--- a/logigator-backend/src/controller/api/project.controller.ts
+++ b/logigator-backend/src/controller/api/project.controller.ts
@@ -28,7 +28,7 @@ import {UpdateProject} from '../../models/request/api/project/update-project';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
 import {ComponentRepository} from '../../database/repositories/component.repository';
-import {buildDependencyResponse, isLegacyFormat, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
+import {buildDependencyResponse, parseStoredCircuit, serializeStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {v4 as uuid} from 'uuid';
 import {getUploadedFileOptions} from '../../functions/get-uploaded-file-options';
 import {ProjectPreviewDark} from '../../database/entities/project-preview-dark.entity';
@@ -79,7 +79,7 @@ export class ProjectController {
 			...classToPlain(project, {groups: ['showShareLinks']}),
 			dependencies: buildDependencyResponse(dependencies, enriched),
 			elements,
-			legacyFormat: isLegacyFormat(elements, snapshots)
+			legacyFormat: !project.newFormat
 		};
 	}
 
@@ -97,6 +97,7 @@ export class ProjectController {
 			project.elementsFile = new ProjectFile();
 
 		project.elementsFile.setFileContent(serializeStoredCircuit(body.elements, body.dependencies, previous.snapshots));
+		project.newFormat = body.newFormat ?? false;
 		project.lastEdited = new Date();
 
 		const deps = [];

--- a/logigator-backend/src/controller/api/share.controller.ts
+++ b/logigator-backend/src/controller/api/share.controller.ts
@@ -10,7 +10,7 @@ import {ComponentRepository} from '../../database/repositories/component.reposit
 import {UserRepository} from '../../database/repositories/user.repository';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
-import {ProjectElement} from '../../models/request/api/project-element';
+import {buildDependencyResponse, parseStoredCircuit} from '../../functions/circuit-content';
 import {Project} from '../../database/entities/project.entity';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {Component} from '../../database/entities/component.entity';
@@ -47,13 +47,13 @@ export class ShareController {
 			}
 		});
 		const contentBuffer = await project.elementsFile?.getFileContent();
-		const content: ProjectElement[] = contentBuffer?.length ? JSON.parse(contentBuffer.toString()) : [];
+		const {elements, snapshots} = parseStoredCircuit(contentBuffer);
 
 		return {
 			type: project instanceof Project ? 'project' : 'comp',
 			...classToPlain(project),
-			dependencies,
-			elements: content ?? []
+			dependencies: buildDependencyResponse(dependencies, snapshots, ['showShareLinks']),
+			elements
 		};
 	}
 

--- a/logigator-backend/src/controller/api/share.controller.ts
+++ b/logigator-backend/src/controller/api/share.controller.ts
@@ -10,7 +10,7 @@ import {ComponentRepository} from '../../database/repositories/component.reposit
 import {UserRepository} from '../../database/repositories/user.repository';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
-import {buildDependencyResponse, parseStoredCircuit} from '../../functions/circuit-content';
+import {buildDependencyResponse, parseStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {Project} from '../../database/entities/project.entity';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {Component} from '../../database/entities/component.entity';
@@ -48,11 +48,12 @@ export class ShareController {
 		});
 		const contentBuffer = await project.elementsFile?.getFileContent();
 		const {elements, snapshots} = parseStoredCircuit(contentBuffer);
+		const enriched = await synthesizeMissingSnapshots(dependencies, snapshots);
 
 		return {
 			type: project instanceof Project ? 'project' : 'comp',
 			...classToPlain(project),
-			dependencies: buildDependencyResponse(dependencies, snapshots, ['showShareLinks']),
+			dependencies: buildDependencyResponse(dependencies, enriched, ['showShareLinks']),
 			elements
 		};
 	}

--- a/logigator-backend/src/controller/api/share.controller.ts
+++ b/logigator-backend/src/controller/api/share.controller.ts
@@ -10,7 +10,7 @@ import {ComponentRepository} from '../../database/repositories/component.reposit
 import {UserRepository} from '../../database/repositories/user.repository';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
-import {buildDependencyResponse, isLegacyFormat, parseStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
+import {buildDependencyResponse, parseStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {Project} from '../../database/entities/project.entity';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {Component} from '../../database/entities/component.entity';
@@ -55,7 +55,7 @@ export class ShareController {
 			...classToPlain(project),
 			dependencies: buildDependencyResponse(dependencies, enriched, ['showShareLinks']),
 			elements,
-			legacyFormat: isLegacyFormat(elements, snapshots)
+			legacyFormat: !project.newFormat
 		};
 	}
 

--- a/logigator-backend/src/controller/api/share.controller.ts
+++ b/logigator-backend/src/controller/api/share.controller.ts
@@ -55,7 +55,7 @@ export class ShareController {
 			...classToPlain(project),
 			dependencies: buildDependencyResponse(dependencies, enriched, ['showShareLinks']),
 			elements,
-			legacyFormat: !project.newFormat
+			newFormat: project.newFormat
 		};
 	}
 

--- a/logigator-backend/src/controller/api/share.controller.ts
+++ b/logigator-backend/src/controller/api/share.controller.ts
@@ -10,7 +10,7 @@ import {ComponentRepository} from '../../database/repositories/component.reposit
 import {UserRepository} from '../../database/repositories/user.repository';
 import {ProjectDependencyRepository} from '../../database/repositories/project-dependency.repository';
 import {classToPlain} from 'class-transformer';
-import {buildDependencyResponse, parseStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
+import {buildDependencyResponse, isLegacyFormat, parseStoredCircuit, synthesizeMissingSnapshots} from '../../functions/circuit-content';
 import {Project} from '../../database/entities/project.entity';
 import {ComponentDependencyRepository} from '../../database/repositories/component-dependency.repository';
 import {Component} from '../../database/entities/component.entity';
@@ -54,7 +54,8 @@ export class ShareController {
 			type: project instanceof Project ? 'project' : 'comp',
 			...classToPlain(project),
 			dependencies: buildDependencyResponse(dependencies, enriched, ['showShareLinks']),
-			elements
+			elements,
+			legacyFormat: isLegacyFormat(elements, snapshots)
 		};
 	}
 

--- a/logigator-backend/src/database/entities/component.entity.ts
+++ b/logigator-backend/src/database/entities/component.entity.ts
@@ -107,8 +107,8 @@ export class Component {
 
 	/**
 	 * Set by the new editor on save; absent on saves by the old editor or old API
-	 * clients, which default it to `false` (legacy). The read responses derive
-	 * `legacyFormat` from it so the editors can warn on a version mismatch.
+	 * clients, which default it to `false` (legacy). The read responses return it
+	 * as `newFormat` so the editors can warn on a version mismatch.
 	 */
 	@Column({default: false, nullable: false})
 	newFormat: boolean;

--- a/logigator-backend/src/database/entities/component.entity.ts
+++ b/logigator-backend/src/database/entities/component.entity.ts
@@ -105,6 +105,14 @@ export class Component {
 	@Column({default: false, nullable: false})
 	public: boolean;
 
+	/**
+	 * Set by the new editor on save; absent on saves by the old editor or old API
+	 * clients, which default it to `false` (legacy). The read responses derive
+	 * `legacyFormat` from it so the editors can warn on a version mismatch.
+	 */
+	@Column({default: false, nullable: false})
+	newFormat: boolean;
+
 	@ManyToOne(() => Component, object => object.forks, {nullable: true, onDelete: 'SET NULL'})
 	forkedFrom: Promise<Component>;
 

--- a/logigator-backend/src/database/entities/project.entity.ts
+++ b/logigator-backend/src/database/entities/project.entity.ts
@@ -73,8 +73,8 @@ export class Project {
 
 	/**
 	 * Set by the new editor on save; absent on saves by the old editor or old API
-	 * clients, which default it to `false` (legacy). The read responses derive
-	 * `legacyFormat` from it so the editors can warn on a version mismatch.
+	 * clients, which default it to `false` (legacy). The read responses return it
+	 * as `newFormat` so the editors can warn on a version mismatch.
 	 */
 	@Column({default: false, nullable: false})
 	newFormat: boolean;

--- a/logigator-backend/src/database/entities/project.entity.ts
+++ b/logigator-backend/src/database/entities/project.entity.ts
@@ -71,6 +71,14 @@ export class Project {
 	@Column({default: false, nullable: false})
 	public: boolean;
 
+	/**
+	 * Set by the new editor on save; absent on saves by the old editor or old API
+	 * clients, which default it to `false` (legacy). The read responses derive
+	 * `legacyFormat` from it so the editors can warn on a version mismatch.
+	 */
+	@Column({default: false, nullable: false})
+	newFormat: boolean;
+
 	@ManyToOne(() => Project, object => object.forks, {nullable: true, onDelete: 'SET NULL'})
 	forkedFrom: Promise<Project>;
 

--- a/logigator-backend/src/database/repositories/component.repository.ts
+++ b/logigator-backend/src/database/repositories/component.repository.ts
@@ -42,6 +42,7 @@ export class ComponentRepository extends PageableRepository<Component> {
 		cloned.numInputs = component.numInputs;
 		cloned.numOutputs = component.numOutputs;
 		cloned.symbol = component.symbol;
+		cloned.newFormat = component.newFormat;
 		cloned.elementsFile = new ComponentFile();
 		if (component.elementsFile) cloned.elementsFile.setFileContent(await component.elementsFile.getFileContent());
 		return this.save(cloned);

--- a/logigator-backend/src/functions/circuit-content.ts
+++ b/logigator-backend/src/functions/circuit-content.ts
@@ -87,6 +87,22 @@ export function serializeStoredCircuit(elements: ProjectElement[], mappings: Pro
 }
 
 /**
+ * Whether a stored circuit predates the new editor's format — it carries neither
+ * embedded snapshots nor port negation. Computed from the *stored* blob (before
+ * read-time snapshot synthesis), so it reflects which editor last saved it. The
+ * editors surface a warning on the version mismatch from this flag.
+ */
+export function isLegacyFormat(elements: ProjectElement[], storedSnapshots: StoredDependencySnapshot[]): boolean {
+	if (storedSnapshots.length > 0)
+		return false;
+
+	return !elements.some(element =>
+		(element.negInputs && element.negInputs.length > 0) ||
+		(element.negOutputs && element.negOutputs.length > 0)
+	);
+}
+
+/**
  * Backfills snapshots for dependency rows that have none stored (e.g. a project
  * authored by the old editor, which embeds nothing). The frozen circuit is
  * reconstructed from the live master's elements + metadata, so the new editor can

--- a/logigator-backend/src/functions/circuit-content.ts
+++ b/logigator-backend/src/functions/circuit-content.ts
@@ -1,0 +1,84 @@
+import {classToPlain} from 'class-transformer';
+import {ProjectElement} from '../models/request/api/project-element';
+import {ProjectMapping} from '../models/request/api/project-mapping';
+import {DependencySnapshot} from '../models/request/api/dependency-snapshot';
+
+/** One embedded dependency snapshot as stored in / read from the circuit blob. */
+interface StoredDependencySnapshot {
+	id: string;
+	model: number;
+	snapshot: DependencySnapshot;
+}
+
+/** Persisted circuit blob carrying embedded snapshots (new clients). */
+interface WrappedCircuit {
+	elements: ProjectElement[];
+	dependencies: StoredDependencySnapshot[];
+}
+
+/**
+ * The elements file historically stored a bare `ProjectElement[]`. New clients
+ * additionally embed per-dependency snapshots, so the blob becomes a
+ * {@link WrappedCircuit}. This reader accepts both shapes and always returns the
+ * unwrapped elements plus any snapshots (empty for legacy blobs).
+ */
+export function parseStoredCircuit(buffer: Buffer | undefined): { elements: ProjectElement[]; snapshots: StoredDependencySnapshot[] } {
+	if (!buffer?.length)
+		return {elements: [], snapshots: []};
+
+	const parsed = JSON.parse(buffer.toString());
+	if (Array.isArray(parsed))
+		return {elements: parsed, snapshots: []};
+
+	return {
+		elements: Array.isArray(parsed.elements) ? parsed.elements : [],
+		snapshots: Array.isArray(parsed.dependencies) ? parsed.dependencies : []
+	};
+}
+
+/**
+ * Serializes the circuit for storage. Stays a bare `ProjectElement[]` (identical
+ * to the legacy shape) when no dependency carries a snapshot, so old clients and
+ * snapshot-free saves are unaffected; wraps only when there is something to embed.
+ */
+export function serializeStoredCircuit(elements: ProjectElement[], mappings: ProjectMapping[]): string {
+	const dependencies: StoredDependencySnapshot[] = mappings
+		.filter(mapping => mapping.snapshot)
+		.map(mapping => ({id: mapping.id, model: mapping.model, snapshot: mapping.snapshot}));
+
+	if (dependencies.length === 0)
+		return JSON.stringify(elements);
+
+	return JSON.stringify({elements, dependencies} as WrappedCircuit);
+}
+
+/**
+ * Builds the `dependencies` field of a circuit read response: the live dependency
+ * rows (so old clients keep resolving always-latest masters) with each embedded
+ * `snapshot` overlaid by matching model id, plus snapshot-only entries for
+ * local-only customs that have no dependency row.
+ */
+export function buildDependencyResponse(depRows: object[], snapshots: StoredDependencySnapshot[], groups?: string[]): object[] {
+	const byModel = new Map<number, DependencySnapshot>();
+	for (const stored of snapshots)
+		byModel.set(stored.model, stored.snapshot);
+
+	const result: any[] = [];
+	const covered = new Set<number>();
+	for (const row of depRows) {
+		const plain: any = classToPlain(row, groups ? {groups} : undefined);
+		const snapshot = byModel.get(plain.model);
+		if (snapshot) {
+			plain.snapshot = snapshot;
+			covered.add(plain.model);
+		}
+		result.push(plain);
+	}
+
+	for (const stored of snapshots) {
+		if (!covered.has(stored.model))
+			result.push({id: stored.id, model: stored.model, snapshot: stored.snapshot});
+	}
+
+	return result;
+}

--- a/logigator-backend/src/functions/circuit-content.ts
+++ b/logigator-backend/src/functions/circuit-content.ts
@@ -3,6 +3,9 @@ import {ProjectElement} from '../models/request/api/project-element';
 import {ProjectMapping} from '../models/request/api/project-mapping';
 import {DependencySnapshot} from '../models/request/api/dependency-snapshot';
 
+/** A type id `>= this` is a custom-component reference (mirrors the editor). */
+const CUSTOM_TYPE_ID_BASE = 1000;
+
 /** One embedded dependency snapshot as stored in / read from the circuit blob. */
 interface StoredDependencySnapshot {
 	id: string;
@@ -14,6 +17,24 @@ interface StoredDependencySnapshot {
 interface WrappedCircuit {
 	elements: ProjectElement[];
 	dependencies: StoredDependencySnapshot[];
+}
+
+/**
+ * The minimal shape of a dependency row needed to synthesize a snapshot from the
+ * live master. Structural so this module stays free of entity imports.
+ */
+interface DependencyRowLike {
+	model_id: number;
+	dependency: {
+		id: string;
+		name: string;
+		symbol: string;
+		description: string;
+		numInputs: number;
+		numOutputs: number;
+		labels: string[];
+		elementsFile?: { getFileContent(): Promise<Buffer> };
+	};
 }
 
 /**
@@ -40,11 +61,24 @@ export function parseStoredCircuit(buffer: Buffer | undefined): { elements: Proj
  * Serializes the circuit for storage. Stays a bare `ProjectElement[]` (identical
  * to the legacy shape) when no dependency carries a snapshot, so old clients and
  * snapshot-free saves are unaffected; wraps only when there is something to embed.
+ *
+ * `carriedSnapshots` are the snapshots already stored for this resource. When a
+ * client sends dependencies but none carry a snapshot (the old editor, which has
+ * no concept of them), the previously stored set is preserved verbatim instead of
+ * being wiped — so an old-editor round-trip no longer strips the frozen circuits.
+ * The whole set is kept (not just the placed top-level ones) to keep each
+ * snapshot's nested-dependency closure intact.
  */
-export function serializeStoredCircuit(elements: ProjectElement[], mappings: ProjectMapping[]): string {
-	const dependencies: StoredDependencySnapshot[] = mappings
+export function serializeStoredCircuit(elements: ProjectElement[], mappings: ProjectMapping[], carriedSnapshots: StoredDependencySnapshot[] = []): string {
+	let dependencies: StoredDependencySnapshot[] = mappings
 		.filter(mapping => mapping.snapshot)
 		.map(mapping => ({id: mapping.id, model: mapping.model, snapshot: mapping.snapshot}));
+
+	// Old editor: sent dependencies but no snapshots -> keep what we already have
+	// rather than dropping it. An empty `mappings` means the client cleared all
+	// customs, so nothing is carried.
+	if (dependencies.length === 0 && mappings.length > 0)
+		dependencies = carriedSnapshots;
 
 	if (dependencies.length === 0)
 		return JSON.stringify(elements);
@@ -53,30 +87,79 @@ export function serializeStoredCircuit(elements: ProjectElement[], mappings: Pro
 }
 
 /**
+ * Backfills snapshots for dependency rows that have none stored (e.g. a project
+ * authored by the old editor, which embeds nothing). The frozen circuit is
+ * reconstructed from the live master's elements + metadata, so the new editor can
+ * render the custom instead of dropping it. Rendered at the master's *current*
+ * state (as-placed state was never stored).
+ *
+ * Only **leaf** masters (whose own elements place no further custom, i.e. no
+ * `t >= CUSTOM_TYPE_ID_BASE`) are synthesized: a hierarchical master's nested
+ * references live in its own file-local id namespace, which would collide with
+ * this document's ids and resolve to the wrong component. Those are left
+ * reference-only (dropped on load), unchanged from before.
+ */
+export async function synthesizeMissingSnapshots(depRows: DependencyRowLike[], snapshots: StoredDependencySnapshot[]): Promise<StoredDependencySnapshot[]> {
+	const covered = new Set(snapshots.map(stored => stored.model));
+	const result = [...snapshots];
+
+	for (const row of depRows) {
+		if (covered.has(row.model_id))
+			continue;
+
+		const master = row.dependency;
+		const {elements} = parseStoredCircuit(await master.elementsFile?.getFileContent());
+		if (elements.some(element => element.t >= CUSTOM_TYPE_ID_BASE))
+			continue;
+
+		result.push({
+			id: master.id,
+			model: row.model_id,
+			snapshot: {
+				version: 1,
+				name: master.name,
+				symbol: master.symbol,
+				description: master.description,
+				numInputs: master.numInputs,
+				numOutputs: master.numOutputs,
+				labels: master.labels ?? [],
+				elements
+			}
+		});
+	}
+
+	return result;
+}
+
+/**
  * Builds the `dependencies` field of a circuit read response: the live dependency
  * rows (so old clients keep resolving always-latest masters) with each embedded
- * `snapshot` overlaid by matching model id, plus snapshot-only entries for
- * local-only customs that have no dependency row.
+ * `snapshot` overlaid, plus snapshot-only entries for local-only customs that have
+ * no dependency row.
+ *
+ * A snapshot is overlaid onto a row matching its model id; when the snapshot also
+ * carries a (non-empty) library id, the row's dependency id must match too, so a
+ * carried-over snapshot can never attach to an unrelated row that happens to reuse
+ * the same file-local model id.
  */
 export function buildDependencyResponse(depRows: object[], snapshots: StoredDependencySnapshot[], groups?: string[]): object[] {
-	const byModel = new Map<number, DependencySnapshot>();
-	for (const stored of snapshots)
-		byModel.set(stored.model, stored.snapshot);
-
 	const result: any[] = [];
-	const covered = new Set<number>();
+	const covered = new Set<StoredDependencySnapshot>();
+
 	for (const row of depRows) {
 		const plain: any = classToPlain(row, groups ? {groups} : undefined);
-		const snapshot = byModel.get(plain.model);
-		if (snapshot) {
-			plain.snapshot = snapshot;
-			covered.add(plain.model);
+		const match = snapshots.find(stored =>
+			stored.model === plain.model && (!stored.id || stored.id === plain.dependency?.id)
+		);
+		if (match) {
+			plain.snapshot = match.snapshot;
+			covered.add(match);
 		}
 		result.push(plain);
 	}
 
 	for (const stored of snapshots) {
-		if (!covered.has(stored.model))
+		if (!covered.has(stored))
 			result.push({id: stored.id, model: stored.model, snapshot: stored.snapshot});
 	}
 

--- a/logigator-backend/src/functions/circuit-content.ts
+++ b/logigator-backend/src/functions/circuit-content.ts
@@ -87,22 +87,6 @@ export function serializeStoredCircuit(elements: ProjectElement[], mappings: Pro
 }
 
 /**
- * Whether a stored circuit predates the new editor's format — it carries neither
- * embedded snapshots nor port negation. Computed from the *stored* blob (before
- * read-time snapshot synthesis), so it reflects which editor last saved it. The
- * editors surface a warning on the version mismatch from this flag.
- */
-export function isLegacyFormat(elements: ProjectElement[], storedSnapshots: StoredDependencySnapshot[]): boolean {
-	if (storedSnapshots.length > 0)
-		return false;
-
-	return !elements.some(element =>
-		(element.negInputs && element.negInputs.length > 0) ||
-		(element.negOutputs && element.negOutputs.length > 0)
-	);
-}
-
-/**
  * Backfills snapshots for dependency rows that have none stored (e.g. a project
  * authored by the old editor, which embeds nothing). The frozen circuit is
  * reconstructed from the live master's elements + metadata, so the new editor can

--- a/logigator-backend/src/models/request/api/component/save-component.ts
+++ b/logigator-backend/src/models/request/api/component/save-component.ts
@@ -1,7 +1,9 @@
 import {
 	IsArray,
+	IsBoolean,
 	IsInt,
 	IsNotEmpty,
+	IsOptional,
 	IsString,
 	Length,
 	NotContains,
@@ -15,6 +17,11 @@ export class SaveComponent {
 	@IsString()
 	@IsNotEmpty()
 	oldHash: string;
+
+	/** Set by the new editor; absent for old clients (treated as legacy). */
+	@IsOptional()
+	@IsBoolean()
+	newFormat: boolean;
 
 	@IsArray()
 	@ValidateNested({each: true})

--- a/logigator-backend/src/models/request/api/dependency-snapshot.ts
+++ b/logigator-backend/src/models/request/api/dependency-snapshot.ts
@@ -1,0 +1,51 @@
+import {
+	IsArray,
+	IsInt,
+	IsString,
+	Length,
+	MaxLength,
+	ValidateNested
+} from 'class-validator';
+import {Type} from 'class-transformer';
+import {ProjectElement} from './project-element';
+
+/**
+ * A frozen copy of a custom dependency's circuit, embedded in a project/component
+ * save so the saved document is self-contained (additive — old clients omit it).
+ * The summary fields are the values as placed, deliberately kept alongside the
+ * frozen `elements` so a stale instance renders at its own port count regardless
+ * of later master edits.
+ */
+export class DependencySnapshot {
+
+	@IsInt()
+	version: number;
+
+	@IsString()
+	@MaxLength(20)
+	name: string;
+
+	@IsString()
+	@MaxLength(5)
+	symbol: string;
+
+	@IsString()
+	@MaxLength(2048)
+	description: string;
+
+	@IsInt()
+	numInputs: number;
+
+	@IsInt()
+	numOutputs: number;
+
+	@IsArray()
+	@IsString({each: true})
+	@Length(0, 5, {each: true})
+	labels: string[];
+
+	@IsArray()
+	@ValidateNested({each: true})
+	@Type(() => ProjectElement)
+	elements: ProjectElement[];
+}

--- a/logigator-backend/src/models/request/api/project-mapping.ts
+++ b/logigator-backend/src/models/request/api/project-mapping.ts
@@ -1,9 +1,27 @@
-import {IsInt, IsUUID} from 'class-validator';
+import {IsInt, IsOptional, IsString, IsUUID, ValidateIf, ValidateNested} from 'class-validator';
+import {Type} from 'class-transformer';
+import {DependencySnapshot} from './dependency-snapshot';
 
 export class ProjectMapping {
+	/**
+	 * The library master's id, or an empty string for a custom that only exists
+	 * locally (never uploaded to the library). Empty-id mappings create no
+	 * dependency row — they are carried solely by their embedded `snapshot`.
+	 */
+	@IsString()
+	@ValidateIf(o => o.id !== '')
 	@IsUUID()
 	id: string;
 
 	@IsInt()
 	model: number;
+
+	/**
+	 * Additive — the frozen embedded circuit. Absent for non-custom dependencies
+	 * and for old write clients (which render the always-latest library master).
+	 */
+	@IsOptional()
+	@ValidateNested()
+	@Type(() => DependencySnapshot)
+	snapshot: DependencySnapshot;
 }

--- a/logigator-backend/src/models/request/api/project/save-project.ts
+++ b/logigator-backend/src/models/request/api/project/save-project.ts
@@ -1,4 +1,4 @@
-import {IsArray, IsNotEmpty, IsString, ValidateNested} from 'class-validator';
+import {IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested} from 'class-validator';
 import {Type} from 'class-transformer';
 import {ProjectElement} from '../project-element';
 import {ProjectMapping} from '../project-mapping';
@@ -7,6 +7,11 @@ export class SaveProject {
 	@IsString()
 	@IsNotEmpty()
 	oldHash: string;
+
+	/** Set by the new editor; absent for old clients (treated as legacy). */
+	@IsOptional()
+	@IsBoolean()
+	newFormat: boolean;
 
 	@IsArray()
 	@ValidateNested({each: true})

--- a/logigator-backend/src/services/share-cloning.service.ts
+++ b/logigator-backend/src/services/share-cloning.service.ts
@@ -86,6 +86,7 @@ export class ShareCloningService {
 		cloned.user = Promise.resolve(user);
 		cloned.forkedFrom = Promise.resolve(project);
 		cloned.createdOn = project.createdOn;
+		cloned.newFormat = project.newFormat;
 		cloned.elementsFile = new ProjectFile();
 		if (project.elementsFile) cloned.elementsFile.setFileContent(await project.elementsFile.getFileContent());
 		const deps = (await projDepRepo.find({

--- a/logigator-editor-v2/src/app/api/models/component.ts
+++ b/logigator-editor-v2/src/app/api/models/component.ts
@@ -48,6 +48,8 @@ export interface SaveComponentRequest {
   numInputs: number;
   numOutputs: number;
   labels: string[];
+  /** Marks the saved circuit as this editor's format (drives the old editor's warning). */
+  newFormat: boolean;
 }
 
 // ---- PATCH /:componentId request ----

--- a/logigator-editor-v2/src/app/api/models/project.ts
+++ b/logigator-editor-v2/src/app/api/models/project.ts
@@ -24,11 +24,11 @@ export interface ProjectDetail extends ProjectSummary {
   dependencies: ProjectDependency[];
   elements: ProjectElement[];
   /**
-   * Additive — `true` when the stored circuit predates this editor's format (no
-   * embedded snapshots, no negation). Saving here converts it, which can degrade
-   * it for the old editor; the load path warns on it.
+   * Additive — `true` when the stored circuit was saved in this editor's format.
+   * Absent/`false` means a legacy project: saving here converts it, which can
+   * degrade it for the old editor; the load path warns on it.
    */
-  legacyFormat?: boolean;
+  newFormat?: boolean;
 }
 
 // ---- POST / request ----

--- a/logigator-editor-v2/src/app/api/models/project.ts
+++ b/logigator-editor-v2/src/app/api/models/project.ts
@@ -45,6 +45,8 @@ export interface SaveProjectRequest {
   oldHash: string;
   dependencies: DependencyMapping[];
   elements: ProjectElement[];
+  /** Marks the saved circuit as this editor's format (drives the old editor's warning). */
+  newFormat: boolean;
 }
 
 // ---- PATCH /:projectId request ----

--- a/logigator-editor-v2/src/app/api/models/project.ts
+++ b/logigator-editor-v2/src/app/api/models/project.ts
@@ -23,6 +23,12 @@ export interface ProjectDependency {
 export interface ProjectDetail extends ProjectSummary {
   dependencies: ProjectDependency[];
   elements: ProjectElement[];
+  /**
+   * Additive — `true` when the stored circuit predates this editor's format (no
+   * embedded snapshots, no negation). Saving here converts it, which can degrade
+   * it for the old editor; the load path warns on it.
+   */
+  legacyFormat?: boolean;
 }
 
 // ---- POST / request ----

--- a/logigator-editor-v2/src/app/app.config.ts
+++ b/logigator-editor-v2/src/app/app.config.ts
@@ -1,9 +1,12 @@
 import {
   ApplicationConfig,
+  inject,
   isDevMode,
+  provideAppInitializer,
   provideZonelessChangeDetection
 } from '@angular/core';
-import { provideTransloco } from '@jsverse/transloco';
+import { firstValueFrom } from 'rxjs';
+import { provideTransloco, TranslocoService } from '@jsverse/transloco';
 import { TranslationLoaderService } from './translation/translation-loader.service';
 import { providePrimeNG } from 'primeng/config';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -56,6 +59,10 @@ export const appConfig: ApplicationConfig = {
       storage: {
         useValue: localStorage
       }
+    }),
+    provideAppInitializer(() => {
+      const transloco = inject(TranslocoService);
+      return firstValueFrom(transloco.load(transloco.getActiveLang()));
     }),
     provideHttpClient()
   ]

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -63,7 +63,7 @@ export class ServerPersistenceGateway {
       link: detail.link
     });
 
-    if (detail.legacyFormat) {
+    if (!detail.newFormat) {
       this.toast.warn(
         'This project was made with the old editor. Saving here converts it to ' +
           'the new format — reopening it in the old editor afterwards may drop or ' +

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -106,7 +106,8 @@ export class ServerPersistenceGateway {
       this.projectApi.save(response.id, {
         oldHash: response.elementsFile?.hash ?? '',
         dependencies,
-        elements
+        elements,
+        newFormat: true
       })
     );
     this.metadataStore.updateHash(
@@ -156,7 +157,8 @@ export class ServerPersistenceGateway {
       this.projectApi.save(response.id, {
         oldHash: response.elementsFile?.hash ?? '',
         dependencies,
-        elements
+        elements,
+        newFormat: true
       })
     );
     this.metadataStore.updateHash(
@@ -468,7 +470,8 @@ export class ServerPersistenceGateway {
         this.projectApi.save(metadata.id, {
           oldHash: metadata.hash,
           dependencies,
-          elements
+          elements,
+          newFormat: true
         })
       );
 
@@ -570,7 +573,8 @@ export class ServerPersistenceGateway {
         elements,
         numInputs: summary.numInputs,
         numOutputs: summary.numOutputs,
-        labels: summary.labels
+        labels: summary.labels,
+        newFormat: true
       })
     );
   }

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -1,4 +1,5 @@
 import { inject, Injectable } from '@angular/core';
+import { TranslocoService } from '@jsverse/transloco';
 import { firstValueFrom, map, Observable, tap } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ProjectApiService } from '../../api/services/project-api.service';
@@ -44,6 +45,7 @@ export class ServerPersistenceGateway {
   private readonly metadataStore = inject(ProjectMetadataStore);
   private readonly toast = inject(ToastService);
   private readonly logging = inject(LoggingService);
+  private readonly transloco = inject(TranslocoService);
   private readonly snapshot = inject(BoardSnapshotService);
 
   async loadProject(uuid: string): Promise<Project> {
@@ -65,9 +67,7 @@ export class ServerPersistenceGateway {
 
     if (!detail.newFormat) {
       this.toast.warn(
-        'This project was made with the old editor. Saving here converts it to ' +
-          'the new format — reopening it in the old editor afterwards may drop or ' +
-          'misrender custom components.'
+        this.transloco.translate('persistence.legacyProjectWarning')
       );
     }
 

--- a/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
+++ b/logigator-editor-v2/src/app/persistence/server/server-persistence.gateway.ts
@@ -63,6 +63,14 @@ export class ServerPersistenceGateway {
       link: detail.link
     });
 
+    if (detail.legacyFormat) {
+      this.toast.warn(
+        'This project was made with the old editor. Saving here converts it to ' +
+          'the new format — reopening it in the old editor afterwards may drop or ' +
+          'misrender custom components.'
+      );
+    }
+
     return project;
   }
 

--- a/logigator-editor-v2/src/app/rendering/image-export.service.spec.ts
+++ b/logigator-editor-v2/src/app/rendering/image-export.service.spec.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock
+} from 'vitest';
 import { Rectangle } from 'pixi.js';
 import { TestBed } from '@angular/core/testing';
 import { configureTestBed } from '../../testing/configure-test-bed';

--- a/logigator-editor-v2/src/app/rendering/image-export.service.ts
+++ b/logigator-editor-v2/src/app/rendering/image-export.service.ts
@@ -88,7 +88,9 @@ export class ImageExportService {
 
   public async exportImage(options: ImageExportOptions): Promise<void> {
     if (!this.snapshot.available) {
-      this.toast.error(this.transloco.translate('imageExport.error.unavailable'));
+      this.toast.error(
+        this.transloco.translate('imageExport.error.unavailable')
+      );
       return;
     }
 

--- a/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.html
+++ b/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.html
@@ -53,7 +53,9 @@
       [ngModelOptions]="{ standalone: true }"
     />
     <label for="export-background">{{ t('imageExport.background') }}</label>
-    <span class="text-sm text-muted">{{ t('imageExport.backgroundHint') }}</span>
+    <span class="text-sm text-muted">{{
+      t('imageExport.backgroundHint')
+    }}</span>
   </div>
   @if (showQuality()) {
     <div class="flex flex-col gap-1">

--- a/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.ts
+++ b/logigator-editor-v2/src/app/ui/export-image-dialog/export-image-dialog.component.ts
@@ -91,7 +91,9 @@ export class ExportImageDialogComponent {
 
   protected readonly dimensions = computed(() => {
     const project = this.project();
-    return project ? this.imageExport.previewSize(project, this.multiplier()) : null;
+    return project
+      ? this.imageExport.previewSize(project, this.multiplier())
+      : null;
   });
 
   protected get canExport(): boolean {

--- a/logigator-editor-v2/src/i18n/en.ts
+++ b/logigator-editor-v2/src/i18n/en.ts
@@ -327,6 +327,10 @@ const en = {
     info: 'Info',
     debug: 'Debug'
   },
+  persistence: {
+    legacyProjectWarning:
+      'This project was made with the old editor. Saving here converts it to the new format — reopening it in the old editor afterwards may drop or misrender custom components.'
+  },
   imageExport: {
     title: 'Export image',
     project: 'Project',

--- a/logigator-editor/src/app/app.module.ts
+++ b/logigator-editor/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { CacheBustingTranslationLoader } from './models/translation/cache-bustin
 import { AppMissingTranslationHandler } from './models/translation/missing-translation-handler';
 import { OutsideNgZoneEventDirective } from './directives/outside-ng-zone-event/outside-ng-zone-event.directive';
 import { UnsavedChangesComponent } from './components/popup-contents/unsaved-changes/unsaved-changes.component';
+import { NewEditorFormatComponent } from './components/popup-contents/new-editor-format/new-editor-format.component';
 import { WorkAreaContainerComponent } from './components/work-area-container/work-area-container.component';
 import { ShareProjectComponent } from './components/popup-contents/share-project/share-project.component';
 import { setStaticDIInjector } from './models/get-di';
@@ -86,6 +87,7 @@ import { MarkdownModule } from 'ngx-markdown';
 		SaveAsComponent,
 		OutsideNgZoneEventDirective,
 		UnsavedChangesComponent,
+		NewEditorFormatComponent,
 		WorkAreaContainerComponent,
 		ShareProjectComponent,
 		ToolbarItemTooltipDirective,

--- a/logigator-editor/src/app/components/popup-contents/new-editor-format/new-editor-format.component.html
+++ b/logigator-editor/src/app/components/popup-contents/new-editor-format/new-editor-format.component.html
@@ -1,0 +1,20 @@
+<div class="new-editor-format">
+	<p>{{ 'POPUP.NEW_EDITOR_FORMAT.INTRO' | translate }}</p>
+	<p>{{ 'POPUP.NEW_EDITOR_FORMAT.UNSUPPORTED' | translate }}</p>
+	<p *ngIf="isSave" class="warning">
+		{{ 'POPUP.NEW_EDITOR_FORMAT.SAVE_WARNING' | translate }}
+	</p>
+	<div class="buttons">
+		<button class="btn-raised primary" (click)="okClick()">
+			{{
+				(isSave
+					? 'POPUP.NEW_EDITOR_FORMAT.SAVE_OK'
+					: 'POPUP.NEW_EDITOR_FORMAT.OK'
+				) | translate
+			}}
+		</button>
+		<button *ngIf="isSave" class="btn-raised danger" (click)="cancelClick()">
+			{{ 'POPUP.NEW_EDITOR_FORMAT.CANCEL' | translate }}
+		</button>
+	</div>
+</div>

--- a/logigator-editor/src/app/components/popup-contents/new-editor-format/new-editor-format.component.scss
+++ b/logigator-editor/src/app/components/popup-contents/new-editor-format/new-editor-format.component.scss
@@ -1,0 +1,22 @@
+.new-editor-format {
+	margin: 2rem 1.5rem;
+	max-width: 32rem;
+
+	p {
+		margin-bottom: 0.75rem;
+	}
+
+	.warning {
+		font-weight: bold;
+	}
+
+	.buttons {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 1.5rem;
+
+		button {
+			margin-left: 0.5rem;
+		}
+	}
+}

--- a/logigator-editor/src/app/components/popup-contents/new-editor-format/new-editor-format.component.ts
+++ b/logigator-editor/src/app/components/popup-contents/new-editor-format/new-editor-format.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { PopupContentComp } from '../../popup/popup-content-comp';
+
+/**
+ * Warns that the open project was saved by the new editor, whose format this
+ * editor only partially supports. Used in two modes via {@link inputFromOpener}:
+ * `open` is an acknowledgement on load; `save` is a blocking confirmation before
+ * a save that would degrade the new-format data (e.g. drop negated ports).
+ */
+@Component({
+	selector: 'app-new-editor-format',
+	templateUrl: './new-editor-format.component.html',
+	styleUrls: ['./new-editor-format.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NewEditorFormatComponent extends PopupContentComp<
+	'open' | 'save',
+	boolean
+> {
+	get isSave(): boolean {
+		return this.inputFromOpener === 'save';
+	}
+
+	okClick() {
+		this.requestClose.emit(true);
+	}
+
+	cancelClick() {
+		this.requestClose.emit(false);
+	}
+}

--- a/logigator-editor/src/app/models/http/response/project-info.ts
+++ b/logigator-editor/src/app/models/http/response/project-info.ts
@@ -11,9 +11,9 @@ export interface ProjectInfo {
 	link: string;
 	public: boolean;
 	/**
-	 * Additive — `true` when the stored circuit predates the new editor's format.
-	 * `false` means it was saved by the new editor (may use features like negated
-	 * ports that this editor does not support). Absent on older backends.
+	 * Additive — `true` when the circuit was saved by the new editor (may use
+	 * features like negated ports that this editor does not support). Absent or
+	 * `false` means a legacy project. Absent on older backends.
 	 */
-	legacyFormat?: boolean;
+	newFormat?: boolean;
 }

--- a/logigator-editor/src/app/models/http/response/project-info.ts
+++ b/logigator-editor/src/app/models/http/response/project-info.ts
@@ -10,4 +10,10 @@ export interface ProjectInfo {
 	};
 	link: string;
 	public: boolean;
+	/**
+	 * Additive — `true` when the stored circuit predates the new editor's format.
+	 * `false` means it was saved by the new editor (may use features like negated
+	 * ports that this editor does not support). Absent on older backends.
+	 */
+	legacyFormat?: boolean;
 }

--- a/logigator-editor/src/app/models/project.ts
+++ b/logigator-editor/src/app/models/project.ts
@@ -23,6 +23,8 @@ export interface ProjectConfiguration {
 	public?: boolean;
 	link?: string;
 	source: 'server' | 'local' | 'share';
+	/** `true` when the loaded circuit was saved by the new editor. */
+	newFormat?: boolean;
 }
 
 export class Project {
@@ -33,6 +35,7 @@ export class Project {
 	private readonly _type: ProjectType;
 	private _hash: string;
 	private readonly _source: 'server' | 'local' | 'share';
+	private readonly _newFormat: boolean;
 
 	private readonly _currState: ProjectState;
 
@@ -60,6 +63,7 @@ export class Project {
 		this._type = config.type ?? 'comp';
 		this._hash = config.hash;
 		this._source = config.source;
+		this._newFormat = config.newFormat ?? false;
 		this._isPublic = config.public ?? false;
 		this._link = config.link;
 		this._currActionPointer = -1;
@@ -820,6 +824,10 @@ export class Project {
 
 	get source(): 'server' | 'local' | 'share' {
 		return this._source;
+	}
+
+	get newFormat(): boolean {
+		return this._newFormat;
 	}
 
 	get isPublic(): boolean {

--- a/logigator-editor/src/app/services/editor-interaction/editor-interaction.service.ts
+++ b/logigator-editor/src/app/services/editor-interaction/editor-interaction.service.ts
@@ -10,6 +10,7 @@ import { PopupService } from '../popup/popup.service';
 import { NewComponentComponent } from '../../components/popup-contents/new-component/new-component.component';
 import { OpenProjectComponent } from '../../components/popup-contents/open/open-project.component';
 import { SaveAsComponent } from '../../components/popup-contents/save-as/save-as.component';
+import { NewEditorFormatComponent } from '../../components/popup-contents/new-editor-format/new-editor-format.component';
 import { ShareProjectComponent } from '../../components/popup-contents/share-project/share-project.component';
 import { ErrorHandlingService } from '../error-handling/error-handling.service';
 import { EditComponentPlugsComponent } from '../../components/popup-contents/edit-component-plugs/edit-component-plugs.component';
@@ -153,6 +154,15 @@ export class EditorInteractionService {
 		) {
 			this.projectsService.saveAllComponents();
 		} else if (this.projectsService.mainProject.source !== 'local') {
+			if (this.projectsService.mainProject.newFormat) {
+				const proceed = await this.popupService.showPopup(
+					NewEditorFormatComponent,
+					'POPUP.NEW_EDITOR_FORMAT.TITLE',
+					true,
+					'save'
+				);
+				if (!proceed) return;
+			}
 			this.projectsService.saveAllProjects();
 		} else {
 			const saveResp = await this.popupService.showPopup(

--- a/logigator-editor/src/app/services/project-save-management/project-save-management.service.spec.ts
+++ b/logigator-editor/src/app/services/project-save-management/project-save-management.service.spec.ts
@@ -1,6 +1,9 @@
 import { TestBed } from '@angular/core/testing';
+import * as PIXI from 'pixi.js';
 
 import { ProjectSaveManagementService } from './project-save-management.service';
+import { Element } from '../../models/element';
+import { ElementTypeId } from '../../models/element-types/element-type-ids';
 
 describe('ProjectSaveManagementService', () => {
 	beforeEach(() => TestBed.configureTestingModule({}));
@@ -10,5 +13,57 @@ describe('ProjectSaveManagementService', () => {
 			ProjectSaveManagementService
 		);
 		expect(service).toBeTruthy();
+	});
+
+	describe('shiftIntoPositiveSpace', () => {
+		// The method is pure (it only mutates the passed array), so it can be
+		// exercised off the prototype without resolving the service's DI graph.
+		const shift = (elements: Element[]): void =>
+			(
+				ProjectSaveManagementService.prototype as unknown as {
+					shiftIntoPositiveSpace(elements: Element[]): void;
+				}
+			).shiftIntoPositiveSpace.call(null, elements);
+
+		const makeElement = (
+			pos: [number, number],
+			endPos?: [number, number]
+		): Element => ({
+			id: 0,
+			typeId: ElementTypeId.AND,
+			numInputs: 2,
+			numOutputs: 1,
+			pos: new PIXI.Point(pos[0], pos[1]),
+			endPos: endPos ? new PIXI.Point(endPos[0], endPos[1]) : undefined
+		});
+
+		it('translates negative positions into positive space', () => {
+			const elements = [makeElement([-3, -5]), makeElement([1, 2])];
+
+			shift(elements);
+
+			expect(elements[0].pos).toEqual(new PIXI.Point(0, 0));
+			expect(elements[1].pos).toEqual(new PIXI.Point(4, 7));
+		});
+
+		it('accounts for wire end points when finding the offset', () => {
+			// pos is positive but endPos reaches into negative space.
+			const wire = makeElement([2, 2], [-4, -1]);
+
+			shift([wire]);
+
+			expect(wire.pos).toEqual(new PIXI.Point(6, 3));
+			expect(wire.endPos).toEqual(new PIXI.Point(0, 0));
+		});
+
+		it('leaves an all-positive project untouched', () => {
+			const elements = [makeElement([0, 0]), makeElement([5, 3], [5, 8])];
+
+			shift(elements);
+
+			expect(elements[0].pos).toEqual(new PIXI.Point(0, 0));
+			expect(elements[1].pos).toEqual(new PIXI.Point(5, 3));
+			expect(elements[1].endPos).toEqual(new PIXI.Point(5, 8));
+		});
 	});
 });

--- a/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
+++ b/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
@@ -713,7 +713,38 @@ export class ProjectSaveManagementService {
 			mapped.push(element);
 		}
 
+		this.shiftIntoPositiveSpace(mapped);
+
 		return mapped;
+	}
+
+	/**
+	 * The chunk grid is indexed by non-negative coordinates, so a project
+	 * authored in the new editor's negative coordinate space crashes on load.
+	 * Translate every element by a uniform offset so the whole project sits in
+	 * positive space again. A pure translation preserves the circuit topology;
+	 * the shifted coordinates persist if the project is saved back.
+	 */
+	private shiftIntoPositiveSpace(elements: Element[]): void {
+		let minX = 0;
+		let minY = 0;
+		for (const element of elements) {
+			minX = Math.min(minX, element.pos.x, element.endPos?.x ?? element.pos.x);
+			minY = Math.min(minY, element.pos.y, element.endPos?.y ?? element.pos.y);
+		}
+
+		if (minX >= 0 && minY >= 0) return;
+
+		const offsetX = -Math.floor(minX);
+		const offsetY = -Math.floor(minY);
+		for (const element of elements) {
+			element.pos.x += offsetX;
+			element.pos.y += offsetY;
+			if (element.endPos) {
+				element.endPos.x += offsetX;
+				element.endPos.y += offsetY;
+			}
+		}
 	}
 
 	private convertElementsToSaveElements(elements: Element[]): {

--- a/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
+++ b/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
@@ -143,6 +143,7 @@ export class ProjectSaveManagementService {
 			hash: projectData.data.elementsFile.hash,
 			public: projectData.data.public,
 			link: projectData.data.link,
+			newFormat: projectData.data.legacyFormat === false,
 			type
 		});
 		this._projectsCache.set(project.id, project);
@@ -646,7 +647,10 @@ export class ProjectSaveManagementService {
 		useLinkForUuid = false
 	): Map<number, number> {
 		const mappingsToApply = new Map<number, number>();
-		dependencies.forEach((dep) => {
+		// New-editor projects may carry snapshot-only dependencies (local custom
+		// components never uploaded to the library) that have no `dependency`. This
+		// editor cannot resolve them; skip so the rest of the project still loads.
+		dependencies.filter((dep) => dep.dependency).forEach((dep) => {
 			const uuid = useLinkForUuid ? dep.dependency.link : dep.dependency.id;
 			if (this._mappings.hasKey(uuid)) {
 				mappingsToApply.set(dep.model, this._mappings.getValue(uuid));
@@ -662,7 +666,7 @@ export class ProjectSaveManagementService {
 		category: 'user' | 'local' | 'share',
 		useLinkForUuid = false
 	) {
-		const elements: Partial<ElementType>[] = components.map((comp) => {
+		const elements: Partial<ElementType>[] = components.filter((comp) => comp).map((comp) => {
 			return {
 				id: this._mappings.getValue(useLinkForUuid ? comp.link : comp.id),
 				description: comp.description,

--- a/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
+++ b/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
@@ -650,14 +650,16 @@ export class ProjectSaveManagementService {
 		// New-editor projects may carry snapshot-only dependencies (local custom
 		// components never uploaded to the library) that have no `dependency`. This
 		// editor cannot resolve them; skip so the rest of the project still loads.
-		dependencies.filter((dep) => dep.dependency).forEach((dep) => {
-			const uuid = useLinkForUuid ? dep.dependency.link : dep.dependency.id;
-			if (this._mappings.hasKey(uuid)) {
-				mappingsToApply.set(dep.model, this._mappings.getValue(uuid));
-			} else {
-				this._mappings.set(uuid, dep.model);
-			}
-		});
+		dependencies
+			.filter((dep) => dep.dependency)
+			.forEach((dep) => {
+				const uuid = useLinkForUuid ? dep.dependency.link : dep.dependency.id;
+				if (this._mappings.hasKey(uuid)) {
+					mappingsToApply.set(dep.model, this._mappings.getValue(uuid));
+				} else {
+					this._mappings.set(uuid, dep.model);
+				}
+			});
 		return mappingsToApply;
 	}
 
@@ -666,19 +668,21 @@ export class ProjectSaveManagementService {
 		category: 'user' | 'local' | 'share',
 		useLinkForUuid = false
 	) {
-		const elements: Partial<ElementType>[] = components.filter((comp) => comp).map((comp) => {
-			return {
-				id: this._mappings.getValue(useLinkForUuid ? comp.link : comp.id),
-				description: comp.description,
-				name: comp.name,
-				minInputs: comp.numInputs,
-				maxInputs: comp.numInputs,
-				symbol: comp.symbol,
-				numInputs: comp.numInputs,
-				numOutputs: comp.numOutputs,
-				labels: comp.labels
-			};
-		});
+		const elements: Partial<ElementType>[] = components
+			.filter((comp) => comp)
+			.map((comp) => {
+				return {
+					id: this._mappings.getValue(useLinkForUuid ? comp.link : comp.id),
+					description: comp.description,
+					name: comp.name,
+					minInputs: comp.numInputs,
+					maxInputs: comp.numInputs,
+					symbol: comp.symbol,
+					numInputs: comp.numInputs,
+					numOutputs: comp.numOutputs,
+					labels: comp.labels
+				};
+			});
 		this.elementProvider.addElements(elements, category);
 	}
 

--- a/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
+++ b/logigator-editor/src/app/services/project-save-management/project-save-management.service.ts
@@ -143,7 +143,7 @@ export class ProjectSaveManagementService {
 			hash: projectData.data.elementsFile.hash,
 			public: projectData.data.public,
 			link: projectData.data.link,
-			newFormat: projectData.data.legacyFormat === false,
+			newFormat: projectData.data.newFormat === true,
 			type
 		});
 		this._projectsCache.set(project.id, project);

--- a/logigator-editor/src/app/services/projects/projects.service.ts
+++ b/logigator-editor/src/app/services/projects/projects.service.ts
@@ -7,6 +7,7 @@ import { delayWhen } from 'rxjs/operators';
 import { ElementProviderService } from '../element-provider/element-provider.service';
 import { ErrorHandlingService } from '../error-handling/error-handling.service';
 import { UnsavedChangesComponent } from '../../components/popup-contents/unsaved-changes/unsaved-changes.component';
+import { NewEditorFormatComponent } from '../../components/popup-contents/new-editor-format/new-editor-format.component';
 import { PopupService } from '../popup/popup.service';
 import { LocationService } from '../location/location.service';
 import { PixiLoaderService } from '../pixi-loader/pixi-loader.service';
@@ -175,6 +176,14 @@ export class ProjectsService {
 			await this.openNewProject(project);
 			this.location.set('project', id);
 			this.errorHandling.showInfo('INFO.PROJECTS.OPEN', { name: project.name });
+			if (project.newFormat) {
+				this.popup.showPopup(
+					NewEditorFormatComponent,
+					'POPUP.NEW_EDITOR_FORMAT.TITLE',
+					true,
+					'open'
+				);
+			}
 		} finally {
 			removeLoading();
 		}

--- a/logigator-editor/src/assets/i18n/de.json
+++ b/logigator-editor/src/assets/i18n/de.json
@@ -91,6 +91,15 @@
 		}
 	},
 	"POPUP": {
+		"NEW_EDITOR_FORMAT": {
+			"TITLE": "Projekt aus dem neuen Editor",
+			"INTRO": "Dieses Projekt wurde mit dem neuen Logigator-Editor erstellt oder zuletzt gespeichert.",
+			"UNSUPPORTED": "Einige Funktionen – etwa negierte Anschlüsse – werden hier nicht unterstützt und fehlen.",
+			"SAVE_WARNING": "Beim Speichern in diesem Editor gehen diese Funktionen verloren und die Ablage benutzerdefinierter Komponenten kann sich ändern. Das kann das Projekt beeinträchtigen, wenn es erneut im neuen Editor geöffnet wird.",
+			"OK": "Verstanden",
+			"SAVE_OK": "Trotzdem speichern",
+			"CANCEL": "Abbrechen"
+		},
 		"NEW_COMP": {
 			"TITLE": "Neue Komponente",
 			"NAME": "Name",

--- a/logigator-editor/src/assets/i18n/en.json
+++ b/logigator-editor/src/assets/i18n/en.json
@@ -91,6 +91,15 @@
 		}
 	},
 	"POPUP": {
+		"NEW_EDITOR_FORMAT": {
+			"TITLE": "Project from the new editor",
+			"INTRO": "This project was created or last saved with the new Logigator editor.",
+			"UNSUPPORTED": "Some of its features — such as negated ports — are not supported here and will be missing.",
+			"SAVE_WARNING": "Saving from this editor will drop those unsupported features and may change how custom components are stored. This can degrade the project when it is opened again in the new editor.",
+			"OK": "Got it",
+			"SAVE_OK": "Save anyway",
+			"CANCEL": "Cancel"
+		},
 		"NEW_COMP": {
 			"TITLE": "New Component",
 			"NAME": "Name",

--- a/logigator-editor/src/assets/i18n/es.json
+++ b/logigator-editor/src/assets/i18n/es.json
@@ -91,6 +91,15 @@
 		}
 	},
 	"POPUP": {
+		"NEW_EDITOR_FORMAT": {
+			"TITLE": "Proyecto del nuevo editor",
+			"INTRO": "Este proyecto se creó o se guardó por última vez con el nuevo editor de Logigator.",
+			"UNSUPPORTED": "Algunas de sus funciones, como los puertos negados, no son compatibles aquí y se perderán.",
+			"SAVE_WARNING": "Guardar desde este editor eliminará esas funciones y puede alterar cómo se almacenan los componentes personalizados. Esto puede degradar el proyecto al abrirlo de nuevo en el nuevo editor.",
+			"OK": "Entendido",
+			"SAVE_OK": "Guardar de todos modos",
+			"CANCEL": "Cancelar"
+		},
 		"NEW_COMP": {
 			"TITLE": "Nuevo componente",
 			"NAME": "Nombre",

--- a/logigator-editor/src/assets/i18n/fr.json
+++ b/logigator-editor/src/assets/i18n/fr.json
@@ -91,6 +91,15 @@
 		}
 	},
 	"POPUP": {
+		"NEW_EDITOR_FORMAT": {
+			"TITLE": "Projet du nouvel éditeur",
+			"INTRO": "Ce projet a été créé ou enregistré pour la dernière fois avec le nouvel éditeur Logigator.",
+			"UNSUPPORTED": "Certaines de ses fonctionnalités — comme les ports inversés — ne sont pas prises en charge ici et seront absentes.",
+			"SAVE_WARNING": "Enregistrer depuis cet éditeur supprimera ces fonctionnalités et peut modifier le stockage des composants personnalisés. Cela peut dégrader le projet lorsqu'il est rouvert dans le nouvel éditeur.",
+			"OK": "Compris",
+			"SAVE_OK": "Enregistrer quand même",
+			"CANCEL": "Annuler"
+		},
 		"NEW_COMP": {
 			"TITLE": "Nouveau composant",
 			"NAME": "Nom",


### PR DESCRIPTION
This pull request introduces support for embedding dependency snapshots within project and component circuit files, enabling self-contained saves and improved compatibility between old and new editors. It adds a new `newFormat` flag to projects and components to indicate the save format, updates the API to handle both legacy and new data structures, and ensures that dependency snapshots are preserved and synthesized as needed. The changes also include new validation logic and data models to support these features.

**Database and Model Changes**
- Added a `newFormat` boolean column to both the `project` and `component` entities to track whether a resource was saved using the new editor format. This is also included in API responses and handled in save/update endpoints. [[1]](diffhunk://#diff-ffbfdfe21d878fe1cedef3e34a4689161e630b6c27921cd6449eb1131032cfb7R1) [[2]](diffhunk://#diff-e2d341d0f9df062a5e59faa9014fa8465374c2fea179d8496e8bb15224113fa2R108-R115) [[3]](diffhunk://#diff-8e35c9b5188b9f66a52317e9efecca4696d44347ddf40ee15239a5f2b28776d2R74-R81) [[4]](diffhunk://#diff-2b3884cd7981a8f6c36b5a7862b5e86cf2d8c404832205caab783ef82e469731R1-R16) [[5]](diffhunk://#diff-a9fa8e48dd315193e7b1720bedec9b50c7f0973b3448f1e7d2590f9f3901b066R21-R25) [[6]](diffhunk://#diff-f435e438130dc222a278d6a47a3358fecfd875f9ac442c599ca6e76ddbf9066dL1-R1)

**Circuit File Format and Dependency Snapshots**
- Introduced new logic for reading and writing circuit files: circuit blobs now support an embedded `dependencies` array carrying frozen dependency snapshots (`DependencySnapshot`). The code can parse both legacy (array) and new (object) formats, and serializes accordingly when saving. [[1]](diffhunk://#diff-cf9d462bb899393b3a9514f5577f1675899a00e0a68e6cae715dbbf77e71f943R1-R167) [[2]](diffhunk://#diff-18f2cbf0cb56b8d3e51b15de14952ffc28cdbfd1beaa134b315a91e69a0b330cL79-R86) [[3]](diffhunk://#diff-18f2cbf0cb56b8d3e51b15de14952ffc28cdbfd1beaa134b315a91e69a0b330cR98-R104) [[4]](diffhunk://#diff-291587cf2fe7b4508f377cced56d08f30edd90a412f89075268c540280c1b6a6L75-R82) [[5]](diffhunk://#diff-291587cf2fe7b4508f377cced56d08f30edd90a412f89075268c540280c1b6a6R94-R109) [[6]](diffhunk://#diff-338c74e9621ef4840dcf5039cea7d880aaec3589a94e1371fdb89924b42223a2L50-R58)
- When saving, if the client is old (doesn't send snapshots), any existing snapshots are preserved to avoid data loss.
- On read, if dependency snapshots are missing (legacy saves), the backend synthesizes them from the current state of the master dependency, but only for leaf dependencies.

**API and Validation Updates**
- Extended the `ProjectMapping` and `SaveComponent`/`SaveProject` models to support optional embedded `snapshot` and the `newFormat` flag, with appropriate validation. [[1]](diffhunk://#diff-a9fa8e48dd315193e7b1720bedec9b50c7f0973b3448f1e7d2590f9f3901b066R3-R6) [[2]](diffhunk://#diff-a9fa8e48dd315193e7b1720bedec9b50c7f0973b3448f1e7d2590f9f3901b066R21-R25) [[3]](diffhunk://#diff-802fd28da758d35cbdae81f45610adae88faa562e7001d2ce7ff7fd9f12bdbf8R1-R51) [[4]](diffhunk://#diff-0b8f7ecc1d826655291e769120573c9b8026fa21b590fd94b065587bc0b875c2L1-R26) [[5]](diffhunk://#diff-f435e438130dc222a278d6a47a3358fecfd875f9ac442c599ca6e76ddbf9066dL1-R1)
- Updated controller logic to handle local-only custom dependencies (those without a library id), ensuring they are not persisted as dependency rows but are included via their embedded snapshot. [[1]](diffhunk://#diff-18f2cbf0cb56b8d3e51b15de14952ffc28cdbfd1beaa134b315a91e69a0b330cR113-R116) [[2]](diffhunk://#diff-291587cf2fe7b4508f377cced56d08f30edd90a412f89075268c540280c1b6a6R94-R109)

**Codebase and Documentation Cleanup**
- Refactored imports and removed unused code related to the previous `ProjectElement` array-only format. [[1]](diffhunk://#diff-18f2cbf0cb56b8d3e51b15de14952ffc28cdbfd1beaa134b315a91e69a0b330cL25-R25) [[2]](diffhunk://#diff-291587cf2fe7b4508f377cced56d08f30edd90a412f89075268c540280c1b6a6L31-R31) [[3]](diffhunk://#diff-338c74e9621ef4840dcf5039cea7d880aaec3589a94e1371fdb89924b42223a2L13-R13)
- Updated documentation in `CLAUDE.md` to remove outdated Docker command instructions.
- Ensured that cloning a component also copies the `newFormat` property.