### PR TITLE
[editor] enable the debug menu from the browser console

### DIFF
--- a/logigator-editor/docs/automation.md
+++ b/logigator-editor/docs/automation.md
@@ -35,7 +35,7 @@ from the bundle**, not merely inert in it — the gate has to be a define rather
 than an `environment` flag for that, and the guarded
 `injector.get(AutomationApiService)` has to stay inlined inside the branch.
 
-`DEBUG_MENU` is *not* that pattern, despite the matching name: the debug menu
+`DEBUG_MENU` is _not_ that pattern, despite the matching name: the debug menu
 ships in every build and its define only sets the initial state, so
 `window.__logigatorDebug()` can switch it on in production.
 

--- a/logigator-editor/docs/automation.md
+++ b/logigator-editor/docs/automation.md
@@ -29,11 +29,15 @@ src/app/automation/
 ## Gating
 
 The `AUTOMATION_API` esbuild define — `true` in the `development` configuration,
-`false` in production (the same pattern as `DEBUG_MENU`; see `src/define.d.ts`).
-When false, the guard in `AppComponent` folds away at build time and this whole
-module tree is **absent from the bundle**, not merely inert in it — the gate has
-to be a define rather than an `environment` flag for that, and the guarded
+`false` in production (see `src/define.d.ts`). When false, the guard in
+`AppComponent` folds away at build time and this whole module tree is **absent
+from the bundle**, not merely inert in it — the gate has to be a define rather
+than an `environment` flag for that, and the guarded
 `injector.get(AutomationApiService)` has to stay inlined inside the branch.
+
+`DEBUG_MENU` is *not* that pattern, despite the matching name: the debug menu
+ships in every build and its define only sets the initial state, so
+`window.__logigatorDebug()` can switch it on in production.
 
 `AppComponent` calls `install()` immediately after `setStaticDIInjector`, because
 the facade builds model objects (`Project`, `Component`) that resolve their

--- a/logigator-editor/docs/rendering.md
+++ b/logigator-editor/docs/rendering.md
@@ -347,7 +347,7 @@ When an inserted element's center falls outside the current root cell — or the
 
 ### Debug introspection
 
-Four methods describe the live tree. The commands that call them sit in the title-bar Debug menu (`DebugMenuService`, gated by the `DEBUG_MENU` define) and run over both trees of the active project, which `Project.quadTrees` exposes for that purpose alone.
+Four methods describe the live tree. The commands that call them sit in the title-bar Debug menu (`DebugMenuService`, shown when `DebugMenuToggleService.enabled()` — the `DEBUG_MENU` define sets its initial state, `window.__logigatorDebug()` flips it at runtime) and run over both trees of the active project, which `Project.quadTrees` exposes for that purpose alone.
 
 The walks themselves live in `quad-tree-debug.ts` as free functions over a root `QuadTreeEntry`, the item map (as a `ReadonlyMap`) and a `QuadTreeLimits` object of the container's thresholds; the four methods on `QuadTreeContainer` are one-line delegates that hand over its internals. `QuadTreeContainer` is insert/remove/query/cull/scale, and every report is a read-only walk no mutation path calls into.
 

--- a/logigator-editor/src/app/app.component.ts
+++ b/logigator-editor/src/app/app.component.ts
@@ -64,6 +64,7 @@ import { HintService } from './onboarding/hint.service';
 import { OnboardingNudgeComponent } from './onboarding/onboarding-nudge.component';
 import { OnboardTargetDirective } from './onboarding/onboard-target.directive';
 import { AutomationApiService } from './automation/automation-api.service';
+import { DebugMenuToggleService } from './ui/debug-menu-toggle.service';
 import { TranslateDirective } from './translation/translate.directive';
 
 @Component({
@@ -114,6 +115,7 @@ export class AppComponent {
   private readonly sessionLifecycleService = inject(SessionLifecycleService);
   private readonly location = inject(Location);
   private readonly workModeService = inject(WorkModeService);
+  private readonly debugMenuToggle = inject(DebugMenuToggleService);
   protected readonly layout = inject(LayoutService);
   protected readonly mobileUi = inject(MobileUiService);
   protected readonly editorSettings = inject(EditorSettingsService);
@@ -183,6 +185,10 @@ export class AppComponent {
     if (AUTOMATION_API) {
       this.injector.get(AutomationApiService).install();
     }
+
+    // Unconditional, unlike the facade above: the console command's whole point
+    // is reaching a build whose DEBUG_MENU define is false.
+    this.debugMenuToggle.install();
 
     // Keep the browser title in sync with the open project's name.
     effect(() => {

--- a/logigator-editor/src/app/ui/debug-menu-toggle.service.spec.ts
+++ b/logigator-editor/src/app/ui/debug-menu-toggle.service.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { configureTestBed } from '../../testing/configure-test-bed';
+import { DebugMenuToggleService } from './debug-menu-toggle.service';
+
+describe('DebugMenuToggleService', () => {
+  let service: DebugMenuToggleService;
+
+  beforeEach(() => {
+    configureTestBed();
+    service = TestBed.inject(DebugMenuToggleService);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    delete window.__logigatorDebug;
+    vi.restoreAllMocks();
+  });
+
+  it('installs a console command that enables by default and takes false', () => {
+    service.install();
+
+    expect(window.__logigatorDebug!()).toBe(true);
+    expect(service.enabled()).toBe(true);
+
+    expect(window.__logigatorDebug!(false)).toBe(false);
+    expect(service.enabled()).toBe(false);
+  });
+});

--- a/logigator-editor/src/app/ui/debug-menu-toggle.service.ts
+++ b/logigator-editor/src/app/ui/debug-menu-toggle.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, signal, type Signal } from '@angular/core';
+
+declare global {
+  interface Window {
+    /**
+     * Turns the title-bar "Debug" menu on (no argument) or off (`false`), and
+     * returns the new state. Installed in every build — see
+     * {@link DebugMenuToggleService}.
+     */
+    __logigatorDebug?: (enabled?: boolean) => boolean;
+  }
+}
+
+/**
+ * Owns whether the title-bar "Debug" menu is part of the menu models, and
+ * publishes the `window.__logigatorDebug()` console command that flips it.
+ *
+ * Holds no dependencies on purpose: this service is constructed at startup in
+ * every build, while `DebugMenuService` — and the half-dozen services its
+ * commands reach — stays unresolved until the menu is actually switched on.
+ *
+ * The `DEBUG_MENU` define is the *initial* state here, not a gate: the debug
+ * menu's module ships in every build so the console command has something to
+ * enable. State is session-only; a reload returns to the build default.
+ */
+@Injectable({ providedIn: 'root' })
+export class DebugMenuToggleService {
+  private readonly _enabled = signal(DEBUG_MENU);
+
+  /** Whether the menu services include the Debug menu. */
+  public readonly enabled: Signal<boolean> = this._enabled.asReadonly();
+
+  /**
+   * Publishes the console command. The menu models are computed off
+   * {@link enabled}, so a write from the browser console schedules change
+   * detection like any other signal write.
+   */
+  public install(): void {
+    window.__logigatorDebug = (enabled = true): boolean => this.set(enabled);
+  }
+
+  /** Returns the new state, so a console call echoes what it did. */
+  public set(enabled: boolean): boolean {
+    this._enabled.set(enabled);
+    // Raw console rather than LoggingService: `loggingVerbosity` drops an
+    // `info` in exactly the builds this command exists for.
+    // eslint-disable-next-line no-console
+    console.log(`[logigator] debug menu ${enabled ? 'enabled' : 'disabled'}`);
+    return enabled;
+  }
+}

--- a/logigator-editor/src/app/ui/debug-menu.service.ts
+++ b/logigator-editor/src/app/ui/debug-menu.service.ts
@@ -19,9 +19,11 @@ import { pickTextFile } from '../utils/file-picker';
  * console (and a toast where a console object is not enough); these are
  * developer tools and are intentionally untranslated.
  *
- * The gate is the `DEBUG_MENU` define at the call sites in `EditorMenuService`,
- * not a check in here: that is what keeps this module — and the commands it
- * reaches — out of a production bundle rather than merely inert inside it.
+ * The gate is `DebugMenuToggleService.enabled()` at the call sites in
+ * `EditorMenuService`, not a check in here. This module ships in every build so
+ * the `window.__logigatorDebug()` console command can reach it in production;
+ * resolving the service inside that guard is what keeps the services these
+ * commands inject unconstructed until the menu is switched on.
  */
 @Injectable({ providedIn: 'root' })
 export class DebugMenuService {

--- a/logigator-editor/src/app/ui/editor-menu.service.ts
+++ b/logigator-editor/src/app/ui/editor-menu.service.ts
@@ -21,6 +21,7 @@ import { ChangelogService } from '../changelog/changelog.service';
 import { DocumentationService } from '../documentation/documentation.service';
 import { OnboardingService } from '../onboarding/onboarding.service';
 import { DebugMenuService } from './debug-menu.service';
+import { DebugMenuToggleService } from './debug-menu-toggle.service';
 import { ConsentService } from '../consent/consent.service';
 import { WireRepairService } from '../project/wire-repair.service';
 import { ToastService } from '../logging/toast.service';
@@ -53,6 +54,7 @@ export class EditorMenuService {
   private readonly consentService = inject(ConsentService);
   private readonly wireRepairService = inject(WireRepairService);
   private readonly legacyEditorService = inject(LegacyEditorService);
+  private readonly debugMenuToggle = inject(DebugMenuToggleService);
 
   /**
    * Rebuilt whenever the active language changes so labels stay translated.
@@ -209,10 +211,10 @@ export class EditorMenuService {
       }
     ];
 
-    // Resolved inline rather than through an `inject()` field or a helper
-    // method: the reference has to sit inside the define guard itself, so a
-    // false DEBUG_MENU drops the service from the bundle (see define.d.ts).
-    if (DEBUG_MENU)
+    // Resolved inside the guard rather than through an `inject()` field: the
+    // debug menu reaches half a dozen services, and none of them should be
+    // constructed in a session that never turns the menu on.
+    if (this.debugMenuToggle.enabled())
       items.push(this.injector.get(DebugMenuService).buildMenuItem());
 
     return items;
@@ -240,7 +242,7 @@ export class EditorMenuService {
       this.aboutItem()
     ];
 
-    if (DEBUG_MENU)
+    if (this.debugMenuToggle.enabled())
       items.push(
         { separator: true },
         this.injector.get(DebugMenuService).buildMenuItem()

--- a/logigator-editor/src/define.d.ts
+++ b/logigator-editor/src/define.d.ts
@@ -18,16 +18,15 @@
  * to be repeated in the `development` block — an omission there is not a
  * compile error, it ships an unsubstituted identifier that throws at runtime.
  *
- * The two module gates below ({@link AUTOMATION_API}, {@link DEBUG_MENU}) are
- * *not* interchangeable with a runtime constant. esbuild substitutes a define
- * while parsing, before it decides which modules are reachable, so a guard
- * around the only reference to a module drops that module from the bundle. A
- * value read at runtime — an object property, or even a bare exported `const` —
- * folds the branch but keeps the module, because reachability was already
- * settled. So for those two: guard the *sole* reference, inline, and never hold
- * the class in an `inject()` field or behind a helper method — both keep it
- * alive regardless. The visual flags have no such constraint; they only gate
- * statements.
+ * The module gate below ({@link AUTOMATION_API}) is *not* interchangeable with
+ * a runtime constant. esbuild substitutes a define while parsing, before it
+ * decides which modules are reachable, so a guard around the only reference to
+ * a module drops that module from the bundle. A value read at runtime — an
+ * object property, or even a bare exported `const` — folds the branch but keeps
+ * the module, because reachability was already settled. So for that one: guard
+ * the *sole* reference, inline, and never hold the class in an `inject()` field
+ * or behind a helper method — both keep it alive regardless. The other flags
+ * have no such constraint; they only gate statements.
  */
 
 /** Git short SHA of the commit the bundle was built from; empty when unstamped. */
@@ -39,7 +38,12 @@ declare const BUILD_DATE: string;
 /** Installs the `window.__logigator` automation facade. False strips it. */
 declare const AUTOMATION_API: boolean;
 
-/** Shows the title-bar "Debug" menu. False strips it and its commands. */
+/**
+ * Initial state of the title-bar "Debug" menu. Unlike {@link AUTOMATION_API}
+ * this is not a module gate — the menu ships in every build so that
+ * `window.__logigatorDebug()` can turn it on in production. Session-only: a
+ * reload returns to this value.
+ */
 declare const DEBUG_MENU: boolean;
 
 /** Outlines every background grid tile in red. */


### PR DESCRIPTION
The menu ships in every build; DEBUG_MENU sets its initial state and window.__logigatorDebug() flips it for the session. DebugMenuService is resolved inside the guard, so its dependencies stay unconstructed while the menu is off.
